### PR TITLE
Support both legacy and new authentication endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+ldlite.db
+ldlite.db.wal
+
 __pycache__
 dist
 ldlite.egg-info

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ $ python -m pip install --upgrade ldlite
 
 (On some systems it might be `python3` rather than `python`.)
 
+> [!Important]
+> The legacy /auth/login endpoint with a non expiring token is going to be removed in the Sunflower release.
+> In the next release of this library the default endpoint to be used will be the newer /authn/login-with-expiry.
+> For more information on these changes see: https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/1396980/Refresh+Token+Rotation+RTR
+
 To extract and transform data:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ $ python -m pip install --upgrade ldlite
 
 (On some systems it might be `python3` rather than `python`.)
 
-> [!Important]
+> [!Warning]
 > The legacy /auth/login endpoint with a non expiring token is going to be removed in the Sunflower release.
 > In the next release of this library the default endpoint to be used will be the newer /authn/login-with-expiry.
+> Because of these changes the connect_okapi_token method will no longer function and will be removed with the release of Sunflower.
 > For more information on these changes see: https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/1396980/Refresh+Token+Rotation+RTR
 
 To extract and transform data:

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -244,18 +244,7 @@ class LDLite:
         self._login()
 
     def connect_okapi_token(self, url, tenant, token):
-        """Connects to an Okapi instance with a login token.
-
-        The *url*, *tenant*, and *token* settings are Okapi-specific
-        connection parameters.
-
-        Example:
-
-            ld.connect_okapi_token(url='https://folio-snapshot-okapi.dev.folio.org',
-                                   tenant='diku',
-                                   token=developer_token)
-
-        """
+        """Deprecated; use connect_okapi(). This will be removed for the Sunflower release. """
         self.okapi_url = url.rstrip('/')
         self.okapi_tenant = tenant
         self.login_token = token

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -379,11 +379,9 @@ class LDLite:
                                 max_retries=self._okapi_max_retries)
             if resp.status_code == 401:
                 # Retry
-                # Warning! There are now an edge case with expiring tokens.
-                # If a request is retried here because of timeout enough times for the token to expire
-                # the token won't automatically be refreshed.
-                # There's also another edge case where a request could have been retried some number of times
-                # before the token expired and then it would be retried for the full _okapi_max_retries value again.
+                # Warning! There is now an edge case with expiring tokens.
+                # If a request has been retried some number of times before the token expired
+                # then it would be retried for the full _okapi_max_retries value again.
                 # This will be cleaned up in future releases after tests are added allow for bigger internal changes.
                 self._login()
                 hdr = {'X-Okapi-Tenant': self.okapi_tenant, 'X-Okapi-Token': self.login_token}
@@ -423,6 +421,12 @@ class LDLite:
                     querycopy['limit'] = str(lim)
                     resp = _request_get(self.okapi_url + path, params=querycopy, headers=hdr,
                                         timeout=self._okapi_timeout, max_retries=self._okapi_max_retries)
+                    if resp.status_code == 401:
+                        # See warning above for retries
+                        self._login()
+                        hdr = {'X-Okapi-Tenant': self.okapi_tenant, 'X-Okapi-Token': self.login_token}
+                        resp = _request_get(self.okapi_url + path, params=querycopy, headers=hdr,
+                            timeout=self._okapi_timeout, max_retries=self._okapi_max_retries)
                     if resp.status_code != 200:
                         raise RuntimeError('HTTP response status code: ' + str(resp.status_code))
                     try:

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -379,6 +379,12 @@ class LDLite:
                                 max_retries=self._okapi_max_retries)
             if resp.status_code == 401:
                 # Retry
+                # Warning! There are now an edge case with expiring tokens.
+                # If a request is retried here because of timeout enough times for the token to expire
+                # the token won't automatically be refreshed.
+                # There's also another edge case where a request could have been retried some number of times
+                # before the token expired and then it would be retried for the full _okapi_max_retries value again.
+                # This will be cleaned up in future releases after tests are added allow for bigger internal changes.
                 self._login()
                 hdr = {'X-Okapi-Tenant': self.okapi_tenant, 'X-Okapi-Token': self.login_token}
                 resp = _request_get(self.okapi_url + path, params=querycopy, headers=hdr, timeout=self._okapi_timeout,


### PR DESCRIPTION
Starting with the Poppy release of FOLIO a new endpoint was introduced for authentication `authn/login-with-expiry`. The existing, legacy endpoint `authn/login` will remain in place until the Sunflower release. More information about this change can be [found in the FOLIO Wiki](https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/1396980/Refresh+Token+Rotation+RTR).

LDLite was hardcoded to use the legacy endpoint. This change adds a flag for LDLite to use either the legacy or the new endpoint. Because LDLite already supported reauthenticating the only change needed was to update the endpoint. This change is intended to be 100% backwards compatible while allowing for users to test using LDLite with the new authentication pattern.

Additionally, because authentication tokens now expire the connect_okapi_token endpoint will stop functioning in the Sunflower release. It has been deprecated.