### PR TITLE
Default to the refresh token auth endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ python -m pip install --upgrade ldlite
 
 > [!Warning]
 > The legacy /auth/login endpoint with a non expiring token is going to be removed in the Sunflower release.
-> In the next release of this library the default endpoint to be used will be the newer /authn/login-with-expiry.
+> As of 1.0.0 this library defaults to using the newer /authn/login-with-expiry.
 > Because of these changes the connect_okapi_token method will no longer function and will be removed with the release of Sunflower.
 > For more information on these changes see: https://folio-org.atlassian.net/wiki/spaces/FOLIJET/pages/1396980/Refresh+Token+Rotation+RTR
 

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -213,7 +213,7 @@ class LDLite:
         if self.db is None:
             raise RuntimeError('database connection not configured: use connect_db() or connect_db_postgresql()')
 
-    def connect_okapi(self, url, tenant, user, password, legacy_auth=True):
+    def connect_okapi(self, url, tenant, user, password, legacy_auth=False):
         """Connects to an Okapi instance with a user name and password.
 
         The *url*, *tenant*, *user*, and *password* settings are Okapi-specific
@@ -222,16 +222,14 @@ class LDLite:
         The *legacy_auth* parameter indicates whether the older /authn/login 
         endpoint with a non-expiring token should be used. Passing False will
         use the newer /authn/login-with-expiry. The legacy login endpoint will
-        be removed as part of the Sunflower release. In the next release this parameter
-        will default to True!
+        be removed as part of the Sunflower release.
 
         Example:
 
             ld.connect_okapi(url='https://folio-snapshot-okapi.dev.folio.org',
                              tenant='diku',
                              user='diku_admin',
-                             password='admin',
-                             legacy_auth=False)
+                             password='admin')
 
         """
         if not url.startswith('https://'):


### PR DESCRIPTION
Defaulting this to False will help make the upgrade to the Sunflower release easier.