### PR TITLE
Lint and fix the main codebase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,10 @@ ignore = ["FBT", "ANN401", "D105", "FIX002", "PLR2004", "TD002", "TD003", "COM81
 pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "S", "INP001", "N813"]
-"src/ldlite/{_csv.py,_select.py,_xlsx.py}" = ["S608"]
+"src/ldlite/{_csv.py,_jsonx.py,_select.py,_xlsx.py}" = ["S608"]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
+[tool.ruff.lint.flake8-annotations]
+mypy-init-return = true
 
 [tool.pdm]
 distribution = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py,_jsonx.py,_select.py,_xlsx.py}"]
+extend-exclude = ["src/ldlite/{__init__.py,_jsonx.py,_select.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py,_jsonx.py,_select.py}"]
+extend-exclude = ["src/ldlite/{__init__.py,_jsonx.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,10 @@ fixable = ["ALL"]
 ignore = ["FBT", "ANN401", "D105", "FIX002", "PLR2004", "TD002", "TD003", "COM812"]
 pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
+"examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 "tests/*" = ["D", "S", "INP001", "N813"]
 "src/ldlite/{_csv.py,_jsonx.py,_select.py,_xlsx.py}" = ["S608"]
-"examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
+"src/ldlite/__init__.py" = ["T201"]
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ ignore = ["FBT", "ANN401", "D105", "FIX002", "PLR2004", "TD002", "TD003", "COM81
 pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "S", "INP001", "N813"]
-"src/ldlite/{_csv.py,_xlsx.py}" = ["S608"]
+"src/ldlite/{_csv.py,_select.py,_xlsx.py}" = ["S608"]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 
 [tool.pdm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ ignore = ["FBT", "ANN401", "D105", "FIX002", "PLR2004", "TD002", "TD003", "COM81
 pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "S", "INP001", "N813"]
+"src/ldlite/_csv.py" = ["S608"]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 
 [tool.pdm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py,_camelcase.py,_csv.py,_jsonx.py,_request.py,_select.py,_sqlx.py,_xlsx.py}"]
+extend-exclude = ["src/ldlite/{__init__.py,_camelcase.py,_csv.py,_jsonx.py,_select.py,_sqlx.py,_xlsx.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py,_jsonx.py}"]
+extend-exclude = ["src/ldlite/{__init__.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py,_camelcase.py,_csv.py,_jsonx.py,_select.py,_sqlx.py,_xlsx.py}"]
+extend-exclude = ["src/ldlite/{__init__.py,_csv.py,_jsonx.py,_select.py,_sqlx.py,_xlsx.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
+extend-exclude = ["src/ldlite/{__init__.py,_camelcase.py,_csv.py,_jsonx.py,_query.py,_request.py,_select.py,_sqlx.py,_xlsx.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]
@@ -54,7 +55,6 @@ pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "S", "INP001", "N813"]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
-"src/*" = ["ALL"]
 
 [tool.pdm]
 distribution = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py,_camelcase.py,_csv.py,_jsonx.py,_query.py,_request.py,_select.py,_sqlx.py,_xlsx.py}"]
+extend-exclude = ["src/ldlite/{__init__.py,_camelcase.py,_csv.py,_jsonx.py,_request.py,_select.py,_sqlx.py,_xlsx.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ ignore = ["FBT", "ANN401", "D105", "FIX002", "PLR2004", "TD002", "TD003", "COM81
 pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["D", "S", "INP001", "N813"]
-"src/ldlite/_csv.py" = ["S608"]
+"src/ldlite/{_csv.py,_xlsx.py}" = ["S608"]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 
 [tool.pdm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py,_csv.py,_jsonx.py,_select.py,_sqlx.py,_xlsx.py}"]
+extend-exclude = ["src/ldlite/{__init__.py,_csv.py,_jsonx.py,_select.py,_xlsx.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ exclude = ["src"]
 
 [tool.ruff]
 target-version = "py39"
-extend-exclude = ["src/ldlite/{__init__.py,_csv.py,_jsonx.py,_select.py,_xlsx.py}"]
+extend-exclude = ["src/ldlite/{__init__.py,_jsonx.py,_select.py,_xlsx.py}"]
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -49,7 +49,7 @@ from ._csv import _to_csv
 from ._jsonx import Attr
 from ._jsonx import _drop_json_tables
 from ._jsonx import _transform_json
-from ._query import _query_dict
+from ._query import query_dict
 # from ._camelcase import _decode_camel_case
 from ._request import _request_get
 from ._select import _select
@@ -363,7 +363,7 @@ class LDLite:
             schema_table = [table]
         if not self._quiet:
             print('ldlite: querying: ' + path, file=sys.stderr)
-        querycopy = _query_dict(query)
+        querycopy = query_dict(query)
         _drop_json_tables(self.db, table)
         _autocommit(self.db, self.dbtype, False)
         try:

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -45,7 +45,7 @@ import psycopg2
 import requests
 from tqdm import tqdm
 
-from ._csv import _to_csv
+from ._csv import to_csv
 from ._jsonx import Attr
 from ._jsonx import _drop_json_tables
 from ._jsonx import _transform_json
@@ -566,7 +566,7 @@ class LDLite:
         self._check_db()
         autocommit(self.db, self.dbtype, False)
         try:
-            _to_csv(self.db, self.dbtype, table, filename, header)
+            to_csv(self.db, self.dbtype, table, filename, header)
             if self.dbtype == DBType.POSTGRES:
                 self.db.rollback()
         finally:

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -51,7 +51,7 @@ from ._jsonx import _drop_json_tables
 from ._jsonx import _transform_json
 from ._query import query_dict
 # from ._camelcase import _decode_camel_case
-from ._request import _request_get
+from ._request import request_get
 from ._select import _select
 from ._sqlx import _DBType
 from ._sqlx import _autocommit
@@ -381,7 +381,7 @@ class LDLite:
             hdr = {'X-Okapi-Tenant': self.okapi_tenant, 'X-Okapi-Token': self.login_token}
             querycopy['offset'] = '0'
             querycopy['limit'] = '1'
-            resp = _request_get(self.okapi_url + path, params=querycopy, headers=hdr, timeout=self._okapi_timeout,
+            resp = request_get(self.okapi_url + path, params=querycopy, headers=hdr, timeout=self._okapi_timeout,
                                 max_retries=self._okapi_max_retries)
             if resp.status_code == 401:
                 # Retry
@@ -391,7 +391,7 @@ class LDLite:
                 # This will be cleaned up in future releases after tests are added allow for bigger internal changes.
                 self._login()
                 hdr = {'X-Okapi-Tenant': self.okapi_tenant, 'X-Okapi-Token': self.login_token}
-                resp = _request_get(self.okapi_url + path, params=querycopy, headers=hdr, timeout=self._okapi_timeout,
+                resp = request_get(self.okapi_url + path, params=querycopy, headers=hdr, timeout=self._okapi_timeout,
                                     max_retries=self._okapi_max_retries)
             if resp.status_code != 200:
                 raise RuntimeError('HTTP response status code: ' + str(resp.status_code))
@@ -425,13 +425,13 @@ class LDLite:
                     lim = self.page_size
                     querycopy['offset'] = str(offset)
                     querycopy['limit'] = str(lim)
-                    resp = _request_get(self.okapi_url + path, params=querycopy, headers=hdr,
+                    resp = request_get(self.okapi_url + path, params=querycopy, headers=hdr,
                                         timeout=self._okapi_timeout, max_retries=self._okapi_max_retries)
                     if resp.status_code == 401:
                         # See warning above for retries
                         self._login()
                         hdr = {'X-Okapi-Tenant': self.okapi_tenant, 'X-Okapi-Token': self.login_token}
-                        resp = _request_get(self.okapi_url + path, params=querycopy, headers=hdr,
+                        resp = request_get(self.okapi_url + path, params=querycopy, headers=hdr,
                             timeout=self._okapi_timeout, max_retries=self._okapi_max_retries)
                     if resp.status_code != 200:
                         raise RuntimeError('HTTP response status code: ' + str(resp.status_code))

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -60,7 +60,7 @@ from ._sqlx import json_type
 from ._sqlx import sqlid
 from ._sqlx import strip_schema
 # from src.ldlite._csv import *
-from ._xlsx import _to_xlsx
+from ._xlsx import to_xlsx
 
 
 # from warnings import warn
@@ -593,7 +593,7 @@ class LDLite:
         self._check_db()
         autocommit(self.db, self.dbtype, False)
         try:
-            _to_xlsx(self.db, self.dbtype, table, filename, header)
+            to_xlsx(self.db, self.dbtype, table, filename, header)
             if self.dbtype == DBType.POSTGRES:
                 self.db.rollback()
         finally:

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -47,8 +47,8 @@ from tqdm import tqdm
 
 from ._csv import to_csv
 from ._jsonx import Attr
-from ._jsonx import _drop_json_tables
-from ._jsonx import _transform_json
+from ._jsonx import drop_json_tables
+from ._jsonx import transform_json
 from ._query import query_dict
 # from ._camelcase import _decode_camel_case
 from ._request import request_get
@@ -269,7 +269,7 @@ class LDLite:
             pass
         finally:
             cur.close()
-        _drop_json_tables(self.db, self.dbtype, table)
+        drop_json_tables(self.db, self.dbtype, table)
 
     def set_folio_max_retries(self, max_retries):
         """Sets the maximum number of retries for FOLIO requests.
@@ -364,7 +364,7 @@ class LDLite:
         if not self._quiet:
             print('ldlite: querying: ' + path, file=sys.stderr)
         querycopy = query_dict(query)
-        _drop_json_tables(self.db, table)
+        drop_json_tables(self.db, table)
         autocommit(self.db, self.dbtype, False)
         try:
             cur = self.db.cursor()
@@ -471,7 +471,7 @@ class LDLite:
             newtables = [table]
             newattrs = {}
             if json_depth > 0:
-                jsontables, jsonattrs = _transform_json(self.db, self.dbtype, table, count, self._quiet, json_depth)
+                jsontables, jsonattrs = transform_json(self.db, self.dbtype, table, count, self._quiet, json_depth)
                 newtables += jsontables
                 newattrs = jsonattrs
                 for t, attrs in newattrs.items():

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -52,7 +52,7 @@ from ._jsonx import _transform_json
 from ._query import query_dict
 # from ._camelcase import _decode_camel_case
 from ._request import request_get
-from ._select import _select
+from ._select import select
 from ._sqlx import DBType
 from ._sqlx import autocommit
 from ._sqlx import encode_sql_str
@@ -543,7 +543,7 @@ class LDLite:
             print('ldlite: reading from table: ' + table, file=sys.stderr)
         autocommit(self.db, self.dbtype, False)
         try:
-            _select(self.db, self.dbtype, table, columns, limit, f)
+            select(self.db, self.dbtype, table, columns, limit, f)
             if self.dbtype == DBType.POSTGRES:
                 self.db.rollback()
         finally:

--- a/src/ldlite/_camelcase.py
+++ b/src/ldlite/_camelcase.py
@@ -4,7 +4,7 @@ def _decode_triple(c1, c2, c3):
     Examines a sequence of three characters c1, c2, and c3; decodes c2; and
     returns the decoded output.
     """
-    b = ''
+    b = ""
     c1u = c1.isupper()
     c2u = c2.isupper()
     c3u = c3.isupper()
@@ -13,7 +13,7 @@ def _decode_triple(c1, c2, c3):
     # First check triples that include zeros
     if c2 == chr(0):
         return b
-    elif c1 == chr(0) and c2 != chr(0):
+    if c1 == chr(0) and c2 != chr(0):
         write = c2.lower()
     elif c1 != chr(0) and c2 != chr(0) and c3 == chr(0):
         if not c1u and c2u:
@@ -21,26 +21,12 @@ def _decode_triple(c1, c2, c3):
             write = c2.lower()
         elif c1u and c2u:
             write = c2.lower()
-        elif not c1u and not c2u:
-            write = c2
-        elif c1u and not c2u:
+        elif (not c1u and not c2u) or (c1u and not c2u):
             write = c2
     # Check triples having no zeros
-    elif not c1u and not c2u and not c3u:
+    elif (not c1u and not c2u and not c3u) or (c1u and not c2u and not c3u) or (not c1u and not c2u and c3u) or (c1u and not c2u and c3u):
         write = c2
-    elif c1u and not c2u and not c3u:
-        write = c2
-    elif not c1u and not c2u and c3u:
-        write = c2
-    elif c1u and not c2u and c3u:
-        write = c2
-    elif not c1u and c2u and not c3u:
-        write_break = True
-        write = c2.lower()
-    elif c1u and c2u and not c3u:
-        write_break = True
-        write = c2.lower()
-    elif not c1u and c2u and c3u:
+    elif (not c1u and c2u and not c3u) or (c1u and c2u and not c3u) or (not c1u and c2u and c3u):
         write_break = True
         write = c2.lower()
     elif c1u and c2u and c3u:
@@ -50,7 +36,7 @@ def _decode_triple(c1, c2, c3):
         raise ValueError('unexpected state: ("' + c1 + '", "' + c2 + '", "' + c3 + '")')
     # Write decoded characters
     if write_break:
-        b += '_'
+        b += "_"
     b += write
     return b
 
@@ -62,7 +48,7 @@ def _decode_camel_case(s):
     last uppercase letter of a sequence is considered the start of a new word
     if it is followed by a lowercase letter.
     """
-    b = ''
+    b = ""
     # c1, c2, and c3 are a sliding window of character triples
     c1 = chr(0)
     _ = c1

--- a/src/ldlite/_camelcase.py
+++ b/src/ldlite/_camelcase.py
@@ -1,4 +1,4 @@
-def _decode_triple(c1, c2, c3):
+def _decode_triple(c1: str, c2: str, c3: str) -> str:
     """Decodes a sliding window of character triples.
 
     Examines a sequence of three characters c1, c2, and c3; decodes c2; and
@@ -41,7 +41,7 @@ def _decode_triple(c1, c2, c3):
     return b
 
 
-def _decode_camel_case(s):
+def decode_camel_case(s: str) -> str:
     """Parses camel case string into lowercase words separated by underscores.
 
     A sequence of uppercase letters is interpreted as a word, except that the

--- a/src/ldlite/_camelcase.py
+++ b/src/ldlite/_camelcase.py
@@ -1,4 +1,4 @@
-def _decode_triple(c1: str, c2: str, c3: str) -> str:
+def _decode_triple(c1: str, c2: str, c3: str) -> str:  # noqa: C901
     """Decodes a sliding window of character triples.
 
     Examines a sequence of three characters c1, c2, and c3; decodes c2; and
@@ -24,9 +24,18 @@ def _decode_triple(c1: str, c2: str, c3: str) -> str:
         elif (not c1u and not c2u) or (c1u and not c2u):
             write = c2
     # Check triples having no zeros
-    elif (not c1u and not c2u and not c3u) or (c1u and not c2u and not c3u) or (not c1u and not c2u and c3u) or (c1u and not c2u and c3u):
+    elif (
+        (not c1u and not c2u and not c3u)
+        or (c1u and not c2u and not c3u)
+        or (not c1u and not c2u and c3u)
+        or (c1u and not c2u and c3u)
+    ):
         write = c2
-    elif (not c1u and c2u and not c3u) or (c1u and c2u and not c3u) or (not c1u and c2u and c3u):
+    elif (
+        (not c1u and c2u and not c3u)
+        or (c1u and c2u and not c3u)
+        or (not c1u and c2u and c3u)
+    ):
         write_break = True
         write = c2.lower()
     elif c1u and c2u and c3u:

--- a/src/ldlite/_csv.py
+++ b/src/ldlite/_csv.py
@@ -14,9 +14,7 @@ def _escape_csv(field: str) -> str:
     return b
 
 
-def to_csv(
-    db: Any, dbtype: DBType, table: str, filename: str, header: bool
-) -> None:
+def to_csv(db: Any, dbtype: DBType, table: str, filename: str, header: bool) -> None:
     # Read attributes
     attrs = []
     cur = db.cursor()

--- a/src/ldlite/_csv.py
+++ b/src/ldlite/_csv.py
@@ -15,7 +15,7 @@ def _escape_csv(field: str) -> str:
 
 
 def to_csv(
-    db: Any, dbtype: DBType, table: str, filename: str, header: list[str]
+    db: Any, dbtype: DBType, table: str, filename: str, header: bool
 ) -> None:
     # Read attributes
     attrs = []

--- a/src/ldlite/_csv.py
+++ b/src/ldlite/_csv.py
@@ -1,5 +1,5 @@
-from ._sqlx import _server_cursor
-from ._sqlx import _sqlid
+from ._sqlx import server_cursor
+from ._sqlx import sqlid
 
 
 def _escape_csv(field):
@@ -17,16 +17,16 @@ def _to_csv(db, dbtype, table, filename, header):
     attrs = []
     cur = db.cursor()
     try:
-        cur.execute('SELECT * FROM ' + _sqlid(table) + ' LIMIT 1')
+        cur.execute('SELECT * FROM ' + sqlid(table) + ' LIMIT 1')
         for a in cur.description:
             attrs.append((a[0], a[1]))
     finally:
         cur.close()
     # Write data
-    cur = _server_cursor(db, dbtype)
+    cur = server_cursor(db, dbtype)
     try:
-        cols = ','.join([_sqlid(a[0]) for a in attrs])
-        cur.execute('SELECT ' + cols + ' FROM ' + _sqlid(table) + ' ORDER BY ' + ','.join(
+        cols = ','.join([sqlid(a[0]) for a in attrs])
+        cur.execute('SELECT ' + cols + ' FROM ' + sqlid(table) + ' ORDER BY ' + ','.join(
             [str(i + 1) for i in range(len(attrs))]))
         fn = filename if '.' in filename else filename + '.csv'
         with open(fn, 'w') as f:

--- a/src/ldlite/_csv.py
+++ b/src/ldlite/_csv.py
@@ -1,9 +1,8 @@
-from ._sqlx import server_cursor
-from ._sqlx import sqlid
+from ._sqlx import server_cursor, sqlid
 
 
 def _escape_csv(field):
-    b = ''
+    b = ""
     for f in field:
         if f == '"':
             b += '""'
@@ -17,7 +16,7 @@ def _to_csv(db, dbtype, table, filename, header):
     attrs = []
     cur = db.cursor()
     try:
-        cur.execute('SELECT * FROM ' + sqlid(table) + ' LIMIT 1')
+        cur.execute("SELECT * FROM " + sqlid(table) + " LIMIT 1")
         for a in cur.description:
             attrs.append((a[0], a[1]))
     finally:
@@ -25,23 +24,23 @@ def _to_csv(db, dbtype, table, filename, header):
     # Write data
     cur = server_cursor(db, dbtype)
     try:
-        cols = ','.join([sqlid(a[0]) for a in attrs])
-        cur.execute('SELECT ' + cols + ' FROM ' + sqlid(table) + ' ORDER BY ' + ','.join(
+        cols = ",".join([sqlid(a[0]) for a in attrs])
+        cur.execute("SELECT " + cols + " FROM " + sqlid(table) + " ORDER BY " + ",".join(
             [str(i + 1) for i in range(len(attrs))]))
-        fn = filename if '.' in filename else filename + '.csv'
-        with open(fn, 'w') as f:
+        fn = filename if "." in filename else filename + ".csv"
+        with open(fn, "w") as f:
             if header:
-                print(','.join(['"' + a[0] + '"' for a in attrs]), file=f)
+                print(",".join(['"' + a[0] + '"' for a in attrs]), file=f)
             while True:
                 row = cur.fetchone()
                 if row is None:
                     break
-                s = ''
+                s = ""
                 for i, data in enumerate(row):
-                    d = '' if data is None else data
+                    d = "" if data is None else data
                     if i != 0:
-                        s += ','
-                    if attrs[i][1] == 'NUMBER' or attrs[i][1] == 20 or attrs[i][1] == 23:
+                        s += ","
+                    if attrs[i][1] == "NUMBER" or attrs[i][1] == 20 or attrs[i][1] == 23:
                         s += str(d)
                     else:
                         s += '"' + _escape_csv(str(d)) + '"'

--- a/src/ldlite/_csv.py
+++ b/src/ldlite/_csv.py
@@ -14,7 +14,9 @@ def _escape_csv(field: str) -> str:
     return b
 
 
-def to_csv(db: Any, dbtype: DBType, table: str, filename: str, header: list[str]) -> None:
+def to_csv(
+    db: Any, dbtype: DBType, table: str, filename: str, header: list[str]
+) -> None:
     # Read attributes
     attrs = []
     cur = db.cursor()
@@ -28,8 +30,14 @@ def to_csv(db: Any, dbtype: DBType, table: str, filename: str, header: list[str]
     cur = server_cursor(db, dbtype)
     try:
         cols = ",".join([sqlid(a[0]) for a in attrs])
-        cur.execute("SELECT " + cols + " FROM " + sqlid(table) + " ORDER BY " + ",".join(
-            [str(i + 1) for i in range(len(attrs))]))
+        cur.execute(
+            "SELECT "
+            + cols
+            + " FROM "
+            + sqlid(table)
+            + " ORDER BY "
+            + ",".join([str(i + 1) for i in range(len(attrs))])
+        )
         fn = Path(filename if "." in filename else filename + ".csv")
         with fn.open("w") as f:
             if header:
@@ -43,7 +51,11 @@ def to_csv(db: Any, dbtype: DBType, table: str, filename: str, header: list[str]
                     d = "" if data is None else data
                     if i != 0:
                         s += ","
-                    if attrs[i][1] == "NUMBER" or attrs[i][1] == 20 or attrs[i][1] == 23:
+                    if (
+                        attrs[i][1] == "NUMBER"
+                        or attrs[i][1] == 20
+                        or attrs[i][1] == 23
+                    ):
                         s += str(d)
                     else:
                         s += '"' + _escape_csv(str(d)) + '"'

--- a/src/ldlite/_csv.py
+++ b/src/ldlite/_csv.py
@@ -1,7 +1,10 @@
-from ._sqlx import server_cursor, sqlid
+from pathlib import Path
+from typing import Any
+
+from ._sqlx import DBType, server_cursor, sqlid
 
 
-def _escape_csv(field):
+def _escape_csv(field: str) -> str:
     b = ""
     for f in field:
         if f == '"':
@@ -11,14 +14,14 @@ def _escape_csv(field):
     return b
 
 
-def _to_csv(db, dbtype, table, filename, header):
+def to_csv(db: Any, dbtype: DBType, table: str, filename: str, header: list[str]) -> None:
     # Read attributes
     attrs = []
     cur = db.cursor()
     try:
         cur.execute("SELECT * FROM " + sqlid(table) + " LIMIT 1")
         for a in cur.description:
-            attrs.append((a[0], a[1]))
+            attrs.extend((a[0], a[1]))
     finally:
         cur.close()
     # Write data
@@ -27,8 +30,8 @@ def _to_csv(db, dbtype, table, filename, header):
         cols = ",".join([sqlid(a[0]) for a in attrs])
         cur.execute("SELECT " + cols + " FROM " + sqlid(table) + " ORDER BY " + ",".join(
             [str(i + 1) for i in range(len(attrs))]))
-        fn = filename if "." in filename else filename + ".csv"
-        with open(fn, "w") as f:
+        fn = Path(filename if "." in filename else filename + ".csv")
+        with fn.open("w") as f:
             if header:
                 print(",".join(['"' + a[0] + '"' for a in attrs]), file=f)
             while True:

--- a/src/ldlite/_jsonx.py
+++ b/src/ldlite/_jsonx.py
@@ -33,12 +33,12 @@ class Attr:
     def __init__(
         self,
         name: str,
-        datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid"],
+        datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid", "bigint"],
         order: None | Literal[1, 2, 3] = None,
         data: Any = None,
     ):
         self.name = name
-        self.datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid"] = (
+        self.datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid", "bigint"] = (
             datatype
         )
         self.order: None | Literal[1, 2, 3] = order

--- a/src/ldlite/_jsonx.py
+++ b/src/ldlite/_jsonx.py
@@ -38,9 +38,9 @@ class Attr:
         data: Any = None,
     ):
         self.name = name
-        self.datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid", "bigint"] = (
-            datatype
-        )
+        self.datatype: Literal[
+            "varchar", "integer", "numeric", "boolean", "uuid", "bigint"
+        ] = datatype
         self.order: None | Literal[1, 2, 3] = order
         self.data = data
 

--- a/src/ldlite/_jsonx.py
+++ b/src/ldlite/_jsonx.py
@@ -30,20 +30,49 @@ def _is_uuid(val: str) -> bool:
 
 
 class Attr:
-    def __init__(self, name: str, datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid"], order: None | Literal[1, 2, 3]=None, data: Any=None):
+    def __init__(
+        self,
+        name: str,
+        datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid"],
+        order: None | Literal[1, 2, 3] = None,
+        data: Any = None,
+    ):
         self.name = name
-        self.datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid"] = datatype
+        self.datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid"] = (
+            datatype
+        )
         self.order: None | Literal[1, 2, 3] = order
         self.data = data
 
     def sqlattr(self, dbtype: DBType) -> str:
-        return sqlid(self.name) + " " + (varchar_type(dbtype) if self.datatype == "varchar" else self.datatype)
+        return (
+            sqlid(self.name)
+            + " "
+            + (varchar_type(dbtype) if self.datatype == "varchar" else self.datatype)
+        )
 
     def __repr__(self) -> str:
         if self.data is None:
-            return "(name=" + self.name + ", datatype=" + self.datatype + ", order=" + str(self.order) + ")"
-        return ("(name=" + self.name + ", datatype=" + self.datatype + ", order=" + str(self.order) + ", data=" +
-                str(self.data) + ")")
+            return (
+                "(name="
+                + self.name
+                + ", datatype="
+                + self.datatype
+                + ", order="
+                + str(self.order)
+                + ")"
+            )
+        return (
+            "(name="
+            + self.name
+            + ", datatype="
+            + self.datatype
+            + ", order="
+            + str(self.order)
+            + ", data="
+            + str(self.data)
+            + ")"
+        )
 
 
 def _old_jtable(table: str) -> str:
@@ -72,7 +101,12 @@ def _old_drop_json_tables(db: Any, table: str) -> None:
                 pass
             finally:
                 cur2.close()
-    except (RuntimeError, psycopg2.Error, sqlite3.OperationalError, duckdb.CatalogException):
+    except (
+        RuntimeError,
+        psycopg2.Error,
+        sqlite3.OperationalError,
+        duckdb.CatalogException,
+    ):
         pass
     finally:
         cur.close()
@@ -103,7 +137,12 @@ def drop_json_tables(db: Any, table: str) -> None:
                 pass
             finally:
                 cur2.close()
-    except (RuntimeError, psycopg2.Error, sqlite3.OperationalError, duckdb.CatalogException):
+    except (
+        RuntimeError,
+        psycopg2.Error,
+        sqlite3.OperationalError,
+        duckdb.CatalogException,
+    ):
         pass
     finally:
         cur.close()
@@ -131,7 +170,17 @@ def _table_name(parents: list[tuple[int, str]]) -> str:
     return table
 
 
-def _compile_array_attrs(dbtype: DBType, parents: list[tuple[int, str]], prefix: str, jarray: list[dict | list | float | int | Any], newattrs: dict[str, dict[str, Attr]], depth: int, arrayattr: str, max_depth: int, quasikey: dict[str, Attr]) -> None:  # noqa: PLR0913
+def _compile_array_attrs(  # noqa: PLR0913
+    dbtype: DBType,
+    parents: list[tuple[int, str]],
+    prefix: str,
+    jarray: list[dict | list | float | int | Any],
+    newattrs: dict[str, dict[str, Attr]],
+    depth: int,
+    arrayattr: str,
+    max_depth: int,
+    quasikey: dict[str, Attr],
+) -> None:
     if depth > max_depth:
         return
     table = _table_name(parents)
@@ -152,12 +201,29 @@ def _compile_array_attrs(dbtype: DBType, parents: list[tuple[int, str]], prefix:
             # TODO: ???
             continue
         elif isinstance(v, (float, int)):
-            newattrs[table][arrayattr] = Attr(decode_camel_case(arrayattr), "numeric", order=3)
+            newattrs[table][arrayattr] = Attr(
+                decode_camel_case(arrayattr),
+                "numeric",
+                order=3,
+            )
         else:
-            newattrs[table][arrayattr] = Attr(decode_camel_case(arrayattr), "varchar", order=3)
+            newattrs[table][arrayattr] = Attr(
+                decode_camel_case(arrayattr),
+                "varchar",
+                order=3,
+            )
 
 
-def _compile_attrs(dbtype: DBType, parents: list[tuple[int, str]], prefix: str, jdict: dict[str | None, dict | list | float | int | None| Any], newattrs: dict[str, dict[str, Attr]], depth: int, max_depth: int, quasikey: dict[str, Attr]) -> None:  # noqa: C901, PLR0912, PLR0913
+def _compile_attrs(  # noqa: C901, PLR0912, PLR0913
+    dbtype: DBType,
+    parents: list[tuple[int, str]],
+    prefix: str,
+    jdict: dict[str | None, dict | list | float | int | None | Any],
+    newattrs: dict[str, dict[str, Attr]],
+    depth: int,
+    max_depth: int,
+    quasikey: dict[str, Attr],
+) -> None:
     if depth > max_depth:
         return
     table = _table_name(parents)
@@ -172,7 +238,11 @@ def _compile_attrs(dbtype: DBType, parents: list[tuple[int, str]], prefix: str, 
         attr = prefix + k
         if isinstance(v, dict):
             if depth == max_depth:
-                newattrs[table][attr] = Attr(decode_camel_case(attr), "varchar", order=3)
+                newattrs[table][attr] = Attr(
+                    decode_camel_case(attr),
+                    "varchar",
+                    order=3,
+                )
             else:
                 objects.append((attr, v, k))
         elif isinstance(v, list):
@@ -195,15 +265,44 @@ def _compile_attrs(dbtype: DBType, parents: list[tuple[int, str]], prefix: str, 
             newattrs[table][attr] = a
     for b in objects:
         p = [(0, decode_camel_case(b[2]))]
-        _compile_attrs(dbtype, parents + p, decode_camel_case(b[0]) + "__", b[1], newattrs, depth + 1, max_depth, qkey)
+        _compile_attrs(
+            dbtype,
+            parents + p,
+            decode_camel_case(b[0]) + "__",
+            b[1],
+            newattrs,
+            depth + 1,
+            max_depth,
+            qkey,
+        )
     for y in arrays:
         p = [(1, decode_camel_case(y[2]))]
-        _compile_array_attrs(dbtype, parents + p, decode_camel_case(y[0]) + "__", y[1], newattrs, depth + 1, y[0],
-                             max_depth, qkey)
+        _compile_array_attrs(
+            dbtype,
+            parents + p,
+            decode_camel_case(y[0]) + "__",
+            y[1],
+            newattrs,
+            depth + 1,
+            y[0],
+            max_depth,
+            qkey,
+        )
 
 
-def _transform_array_data(dbtype: DBType, prefix: str, cur: Any, parents: list[tuple[int, str]], jarray: list[dict | list | float | int | Any], newattrs: dict[str, dict[str, Attr]], depth: int, row_ids: dict[str, int], arrayattr: str, max_depth: int,  # noqa: PLR0913
-                          quasikey: dict[str, Attr]) -> None:
+def _transform_array_data(  # noqa: PLR0913
+    dbtype: DBType,
+    prefix: str,
+    cur: Any,
+    parents: list[tuple[int, str]],
+    jarray: list[dict | list | float | int | Any],
+    newattrs: dict[str, dict[str, Attr]],
+    depth: int,
+    row_ids: dict[str, int],
+    arrayattr: str,
+    max_depth: int,
+    quasikey: dict[str, Attr],
+) -> None:
     if depth > max_depth:
         return
     table = _table_name(parents)
@@ -213,7 +312,18 @@ def _transform_array_data(dbtype: DBType, prefix: str, cur: Any, parents: list[t
         if isinstance(v, dict):
             qkey = {k: quasikey[k] for k in quasikey}
             qkey[prefix + "o"] = Attr(prefix + "o", "integer", data=i + 1)
-            _transform_data(dbtype, prefix, cur, parents, v, newattrs, depth, row_ids, max_depth, qkey)
+            _transform_data(
+                dbtype,
+                prefix,
+                cur,
+                parents,
+                v,
+                newattrs,
+                depth,
+                row_ids,
+                max_depth,
+                qkey,
+            )
             continue
         if isinstance(v, list):
             # TODO: ???
@@ -222,10 +332,19 @@ def _transform_array_data(dbtype: DBType, prefix: str, cur: Any, parents: list[t
         a.data = v
         value = v
         q = "INSERT INTO " + sqlid(table) + "(__id"
-        q += "" if len(quasikey) == 0 else "," + ",".join([sqlid(kv[1].name) for kv in quasikey.items()])
+        q += (
+            ""
+            if len(quasikey) == 0
+            else "," + ",".join([sqlid(kv[1].name) for kv in quasikey.items()])
+        )
         q += "," + prefix + "o," + sqlid(a.name)
         q += ")VALUES(" + str(row_ids[table])
-        q += "" if len(quasikey) == 0 else "," + ",".join([encode_sql(dbtype, kv[1].data) for kv in quasikey.items()])
+        q += (
+            ""
+            if len(quasikey) == 0
+            else ","
+            + ",".join([encode_sql(dbtype, kv[1].data) for kv in quasikey.items()])
+        )
         q += "," + str(i + 1) + "," + encode_sql(dbtype, value) + ")"
         try:
             cur.execute(q)
@@ -234,12 +353,23 @@ def _transform_array_data(dbtype: DBType, prefix: str, cur: Any, parents: list[t
         row_ids[table] += 1
 
 
-def _compile_data(dbtype: DBType, prefix: str, cur: Any, parents: list[tuple[int, str]], jdict: dict[str | None, dict | list | float | int | None |Any], newattrs: dict[str, dict[str, Attr]], depth: int, row_ids: dict[str, int], max_depth: int, quasikey: dict[str, Attr]) -> None | list[tuple[str, Any]]:  # noqa: C901, PLR0912, PLR0913
+def _compile_data(  # noqa: C901, PLR0912, PLR0913
+    dbtype: DBType,
+    prefix: str,
+    cur: Any,
+    parents: list[tuple[int, str]],
+    jdict: dict[str | None, dict | list | float | int | None | Any],
+    newattrs: dict[str, dict[str, Attr]],
+    depth: int,
+    row_ids: dict[str, int],
+    max_depth: int,
+    quasikey: dict[str, Attr],
+) -> None | list[tuple[str, Any]]:
     if depth > max_depth:
         return None
     table = _table_name(parents)
     qkey = {k: quasikey[k] for k in quasikey}
-    row: list[tuple[str, Any]]= []
+    row: list[tuple[str, Any]] = []
     arrays = []
     objects = []
     for k, v in jdict.items():
@@ -265,23 +395,66 @@ def _compile_data(dbtype: DBType, prefix: str, cur: Any, parents: list[tuple[int
                 row.append((a.name, v))
     for b in objects:
         p = [(0, decode_camel_case(b[2]))]
-        r = _compile_data(dbtype, decode_camel_case(b[0]) + "__", cur, parents + p, b[1], newattrs, depth + 1,
-                             row_ids, max_depth, qkey)
+        r = _compile_data(
+            dbtype,
+            decode_camel_case(b[0]) + "__",
+            cur,
+            parents + p,
+            b[1],
+            newattrs,
+            depth + 1,
+            row_ids,
+            max_depth,
+            qkey,
+        )
         if r is not None:
             row += r
     for y in arrays:
         p = [(1, decode_camel_case(y[2]))]
-        _transform_array_data(dbtype, decode_camel_case(y[0]) + "__", cur, parents + p, y[1], newattrs, depth + 1,
-                              row_ids, y[0], max_depth, qkey)
+        _transform_array_data(
+            dbtype,
+            decode_camel_case(y[0]) + "__",
+            cur,
+            parents + p,
+            y[1],
+            newattrs,
+            depth + 1,
+            row_ids,
+            y[0],
+            max_depth,
+            qkey,
+        )
     return row
 
 
-def _transform_data(dbtype: DBType, prefix: str, cur: Any, parents: list[tuple[int, str]], jdict: dict[str | None, dict | list | float | int | None |Any], newattrs: dict[str, dict[str, Attr]], depth: int, row_ids: dict[str, int], max_depth: int, quasikey: dict[str, Attr]) -> None:  # noqa: PLR0913
+def _transform_data(  # noqa: PLR0913
+    dbtype: DBType,
+    prefix: str,
+    cur: Any,
+    parents: list[tuple[int, str]],
+    jdict: dict[str | None, dict | list | float | int | None | Any],
+    newattrs: dict[str, dict[str, Attr]],
+    depth: int,
+    row_ids: dict[str, int],
+    max_depth: int,
+    quasikey: dict[str, Attr],
+) -> None:
     if depth > max_depth:
         return
     table = _table_name(parents)
     row = [(a.name, a.data) for a in quasikey.values()]
-    r = _compile_data(dbtype, prefix, cur, parents, jdict, newattrs, depth, row_ids, max_depth, quasikey)
+    r = _compile_data(
+        dbtype,
+        prefix,
+        cur,
+        parents,
+        jdict,
+        newattrs,
+        depth,
+        row_ids,
+        max_depth,
+        quasikey,
+    )
     if r is not None:
         row += r
     q = "INSERT INTO " + sqlid(table) + "(__id,"
@@ -296,7 +469,14 @@ def _transform_data(dbtype: DBType, prefix: str, cur: Any, parents: list[tuple[i
     row_ids[table] += 1
 
 
-def transform_json(db: Any, dbtype: DBType, table: str, total: int, quiet: bool, max_depth: int) -> tuple[list[str], dict[str, dict[str, Attr]]]:  # noqa: C901, PLR0912, PLR0913, PLR0915
+def transform_json(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    db: Any,
+    dbtype: DBType,
+    table: str,
+    total: int,
+    quiet: bool,
+    max_depth: int,
+) -> tuple[list[str], dict[str, dict[str, Attr]]]:
     # Scan all fields for JSON data
     # First get a list of the string attributes
     str_attrs = []
@@ -315,13 +495,24 @@ def transform_json(db: Any, dbtype: DBType, table: str, total: int, quiet: bool,
     newattrs = {}
     cur = server_cursor(db, dbtype)
     try:
-        cur.execute("SELECT " + ",".join([cast_to_varchar(sqlid(a), dbtype) for a in str_attrs]) + " FROM " +
-                    sqlid(table))
+        cur.execute(
+            "SELECT "
+            + ",".join([cast_to_varchar(sqlid(a), dbtype) for a in str_attrs])
+            + " FROM "
+            + sqlid(table),
+        )
         pbar = None
         pbartotal = 0
         if not quiet:
-            pbar = tqdm(desc="scanning", total=total, leave=False, mininterval=3, smoothing=0, colour="#A9A9A9",
-                        bar_format="{desc} {bar}{postfix}")
+            pbar = tqdm(
+                desc="scanning",
+                total=total,
+                leave=False,
+                mininterval=3,
+                smoothing=0,
+                colour="#A9A9A9",
+                bar_format="{desc} {bar}{postfix}",
+            )
         while True:
             row = cur.fetchone()
             if row is None:
@@ -341,10 +532,23 @@ def transform_json(db: Any, dbtype: DBType, table: str, total: int, quiet: bool,
                     json_attrs.append(attr)
                     json_attrs_set.add(attr)
                 attr_index = json_attrs.index(attr)
-                table_j = table + "__t" if attr_index == 0 else table + "__t" + str(attr_index + 1)
+                table_j = (
+                    table + "__t"
+                    if attr_index == 0
+                    else table + "__t" + str(attr_index + 1)
+                )
                 if table_j not in newattrs:
                     newattrs[table_j] = {}
-                _compile_attrs(dbtype, [(1, table_j)], "", jdict, newattrs, 1, max_depth, {})
+                _compile_attrs(
+                    dbtype,
+                    [(1, table_j)],
+                    "",
+                    jdict,
+                    newattrs,
+                    1,
+                    max_depth,
+                    {},
+                )
             if pbar is not None:
                 pbartotal += 1
                 pbar.update(1)
@@ -360,13 +564,19 @@ def transform_json(db: Any, dbtype: DBType, table: str, total: int, quiet: bool,
             cur.execute("CREATE TABLE " + sqlid(t) + "(__id bigint)")
             for a in attrs.values():
                 if a.order == 1:
-                    cur.execute("ALTER TABLE " + sqlid(t) + " ADD COLUMN " + a.sqlattr(dbtype))
+                    cur.execute(
+                        "ALTER TABLE " + sqlid(t) + " ADD COLUMN " + a.sqlattr(dbtype),
+                    )
             for a in attrs.values():
                 if a.order == 2:
-                    cur.execute("ALTER TABLE " + sqlid(t) + " ADD COLUMN " + a.sqlattr(dbtype))
+                    cur.execute(
+                        "ALTER TABLE " + sqlid(t) + " ADD COLUMN " + a.sqlattr(dbtype),
+                    )
             for a in attrs.values():
                 if a.order == 3:
-                    cur.execute("ALTER TABLE " + sqlid(t) + " ADD COLUMN " + a.sqlattr(dbtype))
+                    cur.execute(
+                        "ALTER TABLE " + sqlid(t) + " ADD COLUMN " + a.sqlattr(dbtype),
+                    )
     finally:
         cur.close()
     db.commit()
@@ -380,13 +590,24 @@ def transform_json(db: Any, dbtype: DBType, table: str, total: int, quiet: bool,
         return [], {}
     cur = server_cursor(db, dbtype)
     try:
-        cur.execute("SELECT " + ",".join([cast_to_varchar(sqlid(a), dbtype) for a in json_attrs]) + " FROM " +
-                    sqlid(table))
+        cur.execute(
+            "SELECT "
+            + ",".join([cast_to_varchar(sqlid(a), dbtype) for a in json_attrs])
+            + " FROM "
+            + sqlid(table),
+        )
         pbar = None
         pbartotal = 0
         if not quiet:
-            pbar = tqdm(desc="transforming", total=total, leave=False, mininterval=3, smoothing=0, colour="#A9A9A9",
-                        bar_format="{desc} {bar}{postfix}")
+            pbar = tqdm(
+                desc="transforming",
+                total=total,
+                leave=False,
+                mininterval=3,
+                smoothing=0,
+                colour="#A9A9A9",
+                bar_format="{desc} {bar}{postfix}",
+            )
         cur2 = db.cursor()
         while True:
             row = cur.fetchone()
@@ -403,13 +624,29 @@ def transform_json(db: Any, dbtype: DBType, table: str, total: int, quiet: bool,
                 except ValueError:
                     continue
                 table_j = table + "__t" if i == 0 else table + "__t" + str(i + 1)
-                _transform_data(dbtype, "", cur2, [(1, table_j)], jdict, newattrs, 1, row_ids, max_depth, {})
+                _transform_data(
+                    dbtype,
+                    "",
+                    cur2,
+                    [(1, table_j)],
+                    jdict,
+                    newattrs,
+                    1,
+                    row_ids,
+                    max_depth,
+                    {},
+                )
             if pbar is not None:
                 pbartotal += 1
                 pbar.update(1)
         if pbar is not None:
             pbar.close()
-    except (RuntimeError, psycopg2.Error, sqlite3.OperationalError, duckdb.CatalogException) as e:
+    except (
+        RuntimeError,
+        psycopg2.Error,
+        sqlite3.OperationalError,
+        duckdb.CatalogException,
+    ) as e:
         raise RuntimeError("running JSON transform: " + str(e)) from e
     finally:
         cur.close()
@@ -417,10 +654,27 @@ def transform_json(db: Any, dbtype: DBType, table: str, total: int, quiet: bool,
     tcatalog = _tcatalog(table)
     cur = db.cursor()
     try:
-        cur.execute("CREATE TABLE " + sqlid(tcatalog) + "(table_name " + varchar_type(dbtype) + " NOT NULL)")
+        cur.execute(
+            "CREATE TABLE "
+            + sqlid(tcatalog)
+            + "(table_name "
+            + varchar_type(dbtype)
+            + " NOT NULL)",
+        )
         for t in newattrs:
-            cur.execute("INSERT INTO " + sqlid(tcatalog) + " VALUES(" + encode_sql(dbtype, t) + ")")
-    except (RuntimeError, psycopg2.Error, sqlite3.OperationalError, duckdb.CatalogException) as e:
+            cur.execute(
+                "INSERT INTO "
+                + sqlid(tcatalog)
+                + " VALUES("
+                + encode_sql(dbtype, t)
+                + ")",
+            )
+    except (
+        RuntimeError,
+        psycopg2.Error,
+        sqlite3.OperationalError,
+        duckdb.CatalogException,
+    ) as e:
         raise RuntimeError("writing table catalog for JSON transform: " + str(e)) from e
     finally:
         cur.close()

--- a/src/ldlite/_jsonx.py
+++ b/src/ldlite/_jsonx.py
@@ -39,7 +39,12 @@ class Attr:
     ):
         self.name = name
         self.datatype: Literal[
-            "varchar", "integer", "numeric", "boolean", "uuid", "bigint"
+            "varchar",
+            "integer",
+            "numeric",
+            "boolean",
+            "uuid",
+            "bigint",
         ] = datatype
         self.order: None | Literal[1, 2, 3] = order
         self.data = data
@@ -483,8 +488,7 @@ def transform_json(  # noqa: C901, PLR0912, PLR0913, PLR0915
     cur = db.cursor()
     try:
         cur.execute("SELECT * FROM " + sqlid(table) + " LIMIT 1")
-        for a in cur.description:
-            str_attrs.extend(a[0])
+        str_attrs.extend([a[0] for a in cur.description])
     finally:
         cur.close()
     # Scan data for JSON objects

--- a/src/ldlite/_jsonx.py
+++ b/src/ldlite/_jsonx.py
@@ -6,7 +6,7 @@ import duckdb
 import psycopg2
 from tqdm import tqdm
 
-from ._camelcase import _decode_camel_case
+from ._camelcase import decode_camel_case
 from ._sqlx import _cast_to_varchar
 from ._sqlx import _encode_sql
 from ._sqlx import _server_cursor
@@ -146,9 +146,9 @@ def _compile_array_attrs(dbtype, parents, prefix, jarray, newattrs, depth, array
             # TODO
             continue
         elif isinstance(v, float) or isinstance(v, int):
-            newattrs[table][arrayattr] = Attr(_decode_camel_case(arrayattr), 'numeric', order=3)
+            newattrs[table][arrayattr] = Attr(decode_camel_case(arrayattr), 'numeric', order=3)
         else:
-            newattrs[table][arrayattr] = Attr(_decode_camel_case(arrayattr), 'varchar', order=3)
+            newattrs[table][arrayattr] = Attr(decode_camel_case(arrayattr), 'varchar', order=3)
 
 
 def _compile_attrs(dbtype, parents, prefix, jdict, newattrs, depth, max_depth, quasikey):
@@ -166,33 +166,33 @@ def _compile_attrs(dbtype, parents, prefix, jdict, newattrs, depth, max_depth, q
         attr = prefix + k
         if isinstance(v, dict):
             if depth == max_depth:
-                newattrs[table][attr] = Attr(_decode_camel_case(attr), 'varchar', order=3)
+                newattrs[table][attr] = Attr(decode_camel_case(attr), 'varchar', order=3)
             else:
                 objects.append((attr, v, k))
         elif isinstance(v, list):
             arrays.append((attr, v, k))
         elif isinstance(v, bool):
-            a = Attr(_decode_camel_case(attr), 'boolean', order=3)
+            a = Attr(decode_camel_case(attr), 'boolean', order=3)
             qkey[attr] = a
             newattrs[table][attr] = a
         elif isinstance(v, float) or isinstance(v, int):
-            a = Attr(_decode_camel_case(attr), 'numeric', order=3)
+            a = Attr(decode_camel_case(attr), 'numeric', order=3)
             qkey[attr] = a
             newattrs[table][attr] = a
         elif dbtype == 2 and _is_uuid(v):
-            a = Attr(_decode_camel_case(attr), 'uuid', order=3)
+            a = Attr(decode_camel_case(attr), 'uuid', order=3)
             qkey[attr] = a
             newattrs[table][attr] = a
         else:
-            a = Attr(_decode_camel_case(attr), 'varchar', order=3)
+            a = Attr(decode_camel_case(attr), 'varchar', order=3)
             qkey[attr] = a
             newattrs[table][attr] = a
     for b in objects:
-        p = [(0, _decode_camel_case(b[2]))]
-        _compile_attrs(dbtype, parents + p, _decode_camel_case(b[0]) + '__', b[1], newattrs, depth + 1, max_depth, qkey)
+        p = [(0, decode_camel_case(b[2]))]
+        _compile_attrs(dbtype, parents + p, decode_camel_case(b[0]) + '__', b[1], newattrs, depth + 1, max_depth, qkey)
     for y in arrays:
-        p = [(1, _decode_camel_case(y[2]))]
-        _compile_array_attrs(dbtype, parents + p, _decode_camel_case(y[0]) + '__', y[1], newattrs, depth + 1, y[0],
+        p = [(1, decode_camel_case(y[2]))]
+        _compile_array_attrs(dbtype, parents + p, decode_camel_case(y[0]) + '__', y[1], newattrs, depth + 1, y[0],
                              max_depth, qkey)
 
 
@@ -275,12 +275,12 @@ def _compile_data(dbtype, prefix, cur, parents, jdict, newattrs, depth, row_ids,
             else:
                 row.append((a.name, v))
     for b in objects:
-        p = [(0, _decode_camel_case(b[2]))]
-        row += _compile_data(dbtype, _decode_camel_case(b[0]) + '__', cur, parents + p, b[1], newattrs, depth + 1,
+        p = [(0, decode_camel_case(b[2]))]
+        row += _compile_data(dbtype, decode_camel_case(b[0]) + '__', cur, parents + p, b[1], newattrs, depth + 1,
                              row_ids, max_depth, qkey)
     for y in arrays:
-        p = [(1, _decode_camel_case(y[2]))]
-        _transform_array_data(dbtype, _decode_camel_case(y[0]) + '__', cur, parents + p, y[1], newattrs, depth + 1,
+        p = [(1, decode_camel_case(y[2]))]
+        _transform_array_data(dbtype, decode_camel_case(y[0]) + '__', cur, parents + p, y[1], newattrs, depth + 1,
                               row_ids, y[0], max_depth, qkey)
     return row
 

--- a/src/ldlite/_query.py
+++ b/src/ldlite/_query.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import copy
 
 
-def _query_dict(query):
-    if query is None:
-        return {}
+def query_dict(query: None | str | dict[str, str]) -> dict[str, str]:
     if isinstance(query, str):
         return {"query": query}
     if isinstance(query, dict):
         return copy.deepcopy(query)
-    raise ValueError('invalid query "' + str(query) + '"')
+
+    return {}

--- a/src/ldlite/_query.py
+++ b/src/ldlite/_query.py
@@ -5,8 +5,7 @@ def _query_dict(query):
     if query is None:
         return {}
     if isinstance(query, str):
-        return {'query': query}
-    elif isinstance(query, dict):
+        return {"query": query}
+    if isinstance(query, dict):
         return copy.deepcopy(query)
-    else:
-        raise ValueError('invalid query "' + str(query) + '"')
+    raise ValueError('invalid query "' + str(query) + '"')

--- a/src/ldlite/_request.py
+++ b/src/ldlite/_request.py
@@ -1,7 +1,7 @@
 import requests
 
 
-def _request_get(
+def request_get(
     url: str,
     params: dict[str, str],
     headers: dict[str, str],

--- a/src/ldlite/_request.py
+++ b/src/ldlite/_request.py
@@ -1,7 +1,13 @@
 import requests
 
 
-def _request_get(url, params, headers, timeout, max_retries):
+def _request_get(
+    url: str,
+    params: dict[str, str],
+    headers: dict[str, str],
+    timeout: int,
+    max_retries: int,
+) -> requests.Response:
     r = 0
     while r < max_retries:
         try:
@@ -10,4 +16,3 @@ def _request_get(url, params, headers, timeout, max_retries):
             pass
         r += 1
     return requests.get(url, params=params, headers=headers, timeout=timeout)
-

--- a/src/ldlite/_select.py
+++ b/src/ldlite/_select.py
@@ -1,20 +1,19 @@
 import sys
 
-from ._sqlx import server_cursor
-from ._sqlx import sqlid
+from ._sqlx import server_cursor, sqlid
 
 
 def _format_attr(attr, width):
-    s = ''
+    s = ""
     a = attr[0]
     len_a = len(a)
     shift_left = 1 if (len_a % 2 == 1 and width % 2 == 0 and len_a < width) else 0
     start = int(width / 2) - int(len_a / 2) - shift_left
-    for i in range(0, start):
-        s += ' '
+    for i in range(start):
+        s += " "
     s += a
-    for i in range(0, width - start - len_a):
-        s += ' '
+    for i in range(width - start - len_a):
+        s += " "
     return s
 
 
@@ -22,8 +21,7 @@ def _maxlen(lines):
     m = 0
     for s in lines:
         len_l = len(s)
-        if len_l > m:
-            m = len_l
+        m = max(m, len_l)
     return m
 
 
@@ -37,57 +35,55 @@ def _rstrip_lines(lines):
 def _format_value(value, dtype):
     if len(value) > 1:
         return value
-    if dtype == 'bool' or dtype == 16:
-        return ['t'] if value[0] == 'True' else ['f']
-    else:
-        return value
+    if dtype == "bool" or dtype == 16:
+        return ["t"] if value[0] == "True" else ["f"]
+    return value
 
 
 def _format_row(row, attrs, width):
-    s = ''
+    s = ""
     # Count number of lines
     rowlines = []
     maxlen = []
     maxlines = 1
     for i, data in enumerate(row):
-        lines = ['']
+        lines = [""]
         if data is not None:
             lines = _format_value(_rstrip_lines(str(data).splitlines()), attrs[i][1])
         maxlen.append(_maxlen(lines))
         rowlines.append(lines)
         lines_len = len(lines)
-        if lines_len > maxlines:
-            maxlines = lines_len
+        maxlines = max(maxlines, lines_len)
     # Write lines
-    for i in range(0, maxlines):
+    for i in range(maxlines):
         for j, lines in enumerate(rowlines):
-            lines_i = lines[i] if i < len(lines) else ''
-            s += ' ' if j == 0 else '| '
-            if attrs[j][1] == 'NUMBER' or attrs[j][1] == 20 or attrs[j][1] == 23:
+            lines_i = lines[i] if i < len(lines) else ""
+            s += " " if j == 0 else "| "
+            if attrs[j][1] == "NUMBER" or attrs[j][1] == 20 or attrs[j][1] == 23:
                 start = width[j] - len(lines_i)
             else:
                 start = 0
-            for k in range(0, start):
-                s += ' '
+            for k in range(start):
+                s += " "
             s += lines_i
-            for k in range(0, width[j] - start - len(lines_i)):
-                s += ' '
-            s += ' '
-        s += '\n'
+            for k in range(width[j] - start - len(lines_i)):
+                s += " "
+            s += " "
+        s += "\n"
     return s
 
 
 def _select(db, dbtype, table, columns, limit, file=sys.stdout):
     if columns is None or columns == []:
-        colspec = '*'
+        colspec = "*"
     else:
-        colspec = ','.join([sqlid(c) for c in columns])
+        colspec = ",".join([sqlid(c) for c in columns])
     # Get attributes
     attrs = []
     width = []
     cur = db.cursor()
     try:
-        cur.execute('SELECT ' + colspec + ' FROM ' + sqlid(table) + ' LIMIT 1')
+        cur.execute("SELECT " + colspec + " FROM " + sqlid(table) + " LIMIT 1")
         for a in cur.description:
             attrs.append((a[0], a[1]))
             width.append(len(a[0]))
@@ -96,42 +92,41 @@ def _select(db, dbtype, table, columns, limit, file=sys.stdout):
     # Scan
     cur = server_cursor(db, dbtype)
     try:
-        cur.execute('SELECT ' + ','.join([sqlid(a[0]) for a in attrs]) + ' FROM ' + sqlid(table))
+        cur.execute("SELECT " + ",".join([sqlid(a[0]) for a in attrs]) + " FROM " + sqlid(table))
         while True:
             row = cur.fetchone()
             if row is None:
                 break
             for i, v in enumerate(row):
-                lines = ['']
+                lines = [""]
                 if v is not None:
                     lines = str(v).splitlines()
                 for j, l in enumerate(lines):
                     len_l = len(l.rstrip())
-                    if len_l > width[i]:
-                        width[i] = len_l
+                    width[i] = max(width[i], len_l)
     finally:
         cur.close()
     cur = server_cursor(db, dbtype)
     try:
-        q = 'SELECT ' + ','.join([sqlid(a[0]) for a in attrs]) + ' FROM ' + sqlid(table)
+        q = "SELECT " + ",".join([sqlid(a[0]) for a in attrs]) + " FROM " + sqlid(table)
         if limit is not None:
-            q += ' LIMIT ' + str(limit)
+            q += " LIMIT " + str(limit)
         cur.execute(q)
         # Attribute names
-        s = ''
+        s = ""
         for i, v in enumerate(attrs):
-            s += ' ' if i == 0 else '| '
-            s += _format_attr(attrs[i], width[i])
-            s += ' '
+            s += " " if i == 0 else "| "
+            s += _format_attr(v, width[i])
+            s += " "
         print(s, file=file)
         # Header bar
-        s = ''
-        for i in range(0, len(attrs)):
-            s += '' if i == 0 else '+'
-            s += '-'
-            for j in range(0, width[i]):
-                s += '-'
-            s += '-'
+        s = ""
+        for i in range(len(attrs)):
+            s += "" if i == 0 else "+"
+            s += "-"
+            for j in range(width[i]):
+                s += "-"
+            s += "-"
         print(s, file=file)
         # Data rows
         row_i = 0
@@ -140,9 +135,9 @@ def _select(db, dbtype, table, columns, limit, file=sys.stdout):
             if row is None:
                 break
             s = _format_row(row, attrs, width)
-            print(s, end='', file=file)
+            print(s, end="", file=file)
             row_i += 1
-        print('(' + str(row_i) + ' ' + ('row' if row_i == 1 else 'rows') + ')', file=file)
-        print('', file=file)
+        print("(" + str(row_i) + " " + ("row" if row_i == 1 else "rows") + ")", file=file)
+        print(file=file)
     finally:
         cur.close()

--- a/src/ldlite/_select.py
+++ b/src/ldlite/_select.py
@@ -79,8 +79,8 @@ def select(  # noqa: C901, PLR0912, PLR0913, PLR0915
     db: Any,
     dbtype: DBType,
     table: str,
-    columns: list[str],
-    limit: int,
+    columns: list[str] | None,
+    limit: int | None,
     file: TextIO = sys.stdout,
 ) -> None:
     if columns is None or columns == []:

--- a/src/ldlite/_select.py
+++ b/src/ldlite/_select.py
@@ -75,7 +75,14 @@ def _format_row(row: list[str], attrs: list[Any], width: list[int]) -> str:
     return s
 
 
-def select(db: Any, dbtype: DBType, table: str, columns: list[str], limit: int, file: TextIO = sys.stdout) -> None:  # noqa: C901, PLR0912, PLR0913, PLR0915
+def select(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    db: Any,
+    dbtype: DBType,
+    table: str,
+    columns: list[str],
+    limit: int,
+    file: TextIO = sys.stdout,
+) -> None:
     if columns is None or columns == []:
         colspec = "*"
     else:
@@ -94,7 +101,9 @@ def select(db: Any, dbtype: DBType, table: str, columns: list[str], limit: int, 
     # Scan
     cur = server_cursor(db, dbtype)
     try:
-        cur.execute("SELECT " + ",".join([sqlid(a[0]) for a in attrs]) + " FROM " + sqlid(table))
+        cur.execute(
+            "SELECT " + ",".join([sqlid(a[0]) for a in attrs]) + " FROM " + sqlid(table)
+        )
         while True:
             row = cur.fetchone()
             if row is None:
@@ -138,7 +147,9 @@ def select(db: Any, dbtype: DBType, table: str, columns: list[str], limit: int, 
             s = _format_row(row, attrs, width)
             print(s, end="", file=file)
             row_i += 1
-        print("(" + str(row_i) + " " + ("row" if row_i == 1 else "rows") + ")", file=file)
+        print(
+            "(" + str(row_i) + " " + ("row" if row_i == 1 else "rows") + ")", file=file
+        )
         print(file=file)
     finally:
         cur.close()

--- a/src/ldlite/_select.py
+++ b/src/ldlite/_select.py
@@ -1,7 +1,7 @@
 import sys
 
-from ._sqlx import _server_cursor
-from ._sqlx import _sqlid
+from ._sqlx import server_cursor
+from ._sqlx import sqlid
 
 
 def _format_attr(attr, width):
@@ -81,22 +81,22 @@ def _select(db, dbtype, table, columns, limit, file=sys.stdout):
     if columns is None or columns == []:
         colspec = '*'
     else:
-        colspec = ','.join([_sqlid(c) for c in columns])
+        colspec = ','.join([sqlid(c) for c in columns])
     # Get attributes
     attrs = []
     width = []
     cur = db.cursor()
     try:
-        cur.execute('SELECT ' + colspec + ' FROM ' + _sqlid(table) + ' LIMIT 1')
+        cur.execute('SELECT ' + colspec + ' FROM ' + sqlid(table) + ' LIMIT 1')
         for a in cur.description:
             attrs.append((a[0], a[1]))
             width.append(len(a[0]))
     finally:
         cur.close()
     # Scan
-    cur = _server_cursor(db, dbtype)
+    cur = server_cursor(db, dbtype)
     try:
-        cur.execute('SELECT ' + ','.join([_sqlid(a[0]) for a in attrs]) + ' FROM ' + _sqlid(table))
+        cur.execute('SELECT ' + ','.join([sqlid(a[0]) for a in attrs]) + ' FROM ' + sqlid(table))
         while True:
             row = cur.fetchone()
             if row is None:
@@ -111,9 +111,9 @@ def _select(db, dbtype, table, columns, limit, file=sys.stdout):
                         width[i] = len_l
     finally:
         cur.close()
-    cur = _server_cursor(db, dbtype)
+    cur = server_cursor(db, dbtype)
     try:
-        q = 'SELECT ' + ','.join([_sqlid(a[0]) for a in attrs]) + ' FROM ' + _sqlid(table)
+        q = 'SELECT ' + ','.join([sqlid(a[0]) for a in attrs]) + ' FROM ' + sqlid(table)
         if limit is not None:
             q += ' LIMIT ' + str(limit)
         cur.execute(q)

--- a/src/ldlite/_sqlx.py
+++ b/src/ldlite/_sqlx.py
@@ -18,7 +18,7 @@ def _strip_schema(table):
     raise ValueError("invalid table name: " + table)
 
 
-def _autocommit(db, dbtype, enable):
+def _autocommit(db, dbtype, enable) -> None:
     if dbtype == _DBType.POSTGRES:
         db.rollback()
         db.set_session(autocommit=enable)
@@ -49,13 +49,13 @@ def _cast_to_varchar(ident: str, dbtype: _DBType):
     return ident + "::varchar"
 
 
-def _varchar_type(dbtype):
+def _varchar_type(dbtype) -> str:
     if dbtype == _DBType.POSTGRES or _DBType.SQLITE:
         return "text"
     return "varchar"
 
 
-def _json_type(dbtype):
+def _json_type(dbtype) -> str:
     if dbtype == _DBType.POSTGRES:
         return "jsonb"
     if dbtype == _DBType.SQLITE:
@@ -64,11 +64,8 @@ def _json_type(dbtype):
 
 
 def _encode_sql_str(dbtype, s):
-    if dbtype == _DBType.POSTGRES:
-        b = "E'"
-    else:
-        b = "'"
-    if dbtype == _DBType.SQLITE or dbtype == _DBType.DUCKDB:
+    b = "E'" if dbtype == _DBType.POSTGRES else "'"
+    if dbtype in (_DBType.SQLITE, _DBType.DUCKDB):
         for c in s:
             if c == "'":
                 b += "''"

--- a/src/ldlite/_sqlx.py
+++ b/src/ldlite/_sqlx.py
@@ -10,13 +10,12 @@ class _DBType(Enum):
 
 
 def _strip_schema(table):
-    st = table.split('.')
+    st = table.split(".")
     if len(st) == 1:
         return table
-    elif len(st) == 2:
+    if len(st) == 2:
         return st[1]
-    else:
-        raise ValueError('invalid table name: ' + table)
+    raise ValueError("invalid table name: " + table)
 
 
 def _autocommit(db, dbtype, enable):
@@ -33,82 +32,77 @@ def _autocommit(db, dbtype, enable):
 
 def _server_cursor(db, dbtype):
     if dbtype == _DBType.POSTGRES:
-        return db.cursor(name=('ldlite' + secrets.token_hex(4)))
-    else:
-        return db.cursor()
+        return db.cursor(name=("ldlite" + secrets.token_hex(4)))
+    return db.cursor()
 
 
 def _sqlid(ident):
-    sp = ident.split('.')
+    sp = ident.split(".")
     if len(sp) == 1:
         return '"' + ident + '"'
-    else:
-        return '.'.join(['"' + s + '"' for s in sp])
+    return ".".join(['"' + s + '"' for s in sp])
 
 
 def _cast_to_varchar(ident: str, dbtype: _DBType):
     if dbtype == _DBType.SQLITE:
-        return 'CAST(' + ident + ' as TEXT)'
-    return ident + '::varchar'
+        return "CAST(" + ident + " as TEXT)"
+    return ident + "::varchar"
 
 
 def _varchar_type(dbtype):
     if dbtype == _DBType.POSTGRES or _DBType.SQLITE:
-        return 'text'
-    else:
-        return 'varchar'
+        return "text"
+    return "varchar"
 
 
 def _json_type(dbtype):
     if dbtype == _DBType.POSTGRES:
-        return 'jsonb'
-    elif dbtype == _DBType.SQLITE:
-        return 'text'
-    else:
-        return 'varchar'
+        return "jsonb"
+    if dbtype == _DBType.SQLITE:
+        return "text"
+    return "varchar"
 
 
 def _encode_sql_str(dbtype, s):
     if dbtype == _DBType.POSTGRES:
-        b = 'E\''
+        b = "E'"
     else:
-        b = '\''
+        b = "'"
     if dbtype == _DBType.SQLITE or dbtype == _DBType.DUCKDB:
         for c in s:
-            if c == '\'':
-                b += '\'\''
+            if c == "'":
+                b += "''"
             else:
                 b += c
     if dbtype == _DBType.POSTGRES:
         for c in s:
-            if c == '\'':
-                b += '\'\''
-            elif c == '\\':
-                b += '\\\\'
-            elif c == '\n':
-                b += '\\n'
-            elif c == '\r':
-                b += '\\r'
-            elif c == '\t':
-                b += '\\t'
-            elif c == '\f':
-                b += '\\f'
-            elif c == '\b':
-                b += '\\b'
+            if c == "'":
+                b += "''"
+            elif c == "\\":
+                b += "\\\\"
+            elif c == "\n":
+                b += "\\n"
+            elif c == "\r":
+                b += "\\r"
+            elif c == "\t":
+                b += "\\t"
+            elif c == "\f":
+                b += "\\f"
+            elif c == "\b":
+                b += "\\b"
             else:
                 b += c
-    b += '\''
+    b += "'"
     return b
 
 
 def _encode_sql(dbtype, data):
     if data is None:
-        return 'NULL'
-    elif isinstance(data, str):
+        return "NULL"
+    if isinstance(data, str):
         return _encode_sql_str(dbtype, data)
-    elif isinstance(data, int):
+    if isinstance(data, int):
         return str(data)
-    elif isinstance(data, bool):
-        return 'TRUE' if data else 'FALSE'
-    else:
-        return _encode_sql_str(dbtype, str(data))
+    if isinstance(data, bool):
+        return "TRUE" if data else "FALSE"
+    return _encode_sql_str(dbtype, str(data))

--- a/src/ldlite/_xlsx.py
+++ b/src/ldlite/_xlsx.py
@@ -1,7 +1,6 @@
 import xlsxwriter
 
-from ._sqlx import server_cursor
-from ._sqlx import sqlid
+from ._sqlx import server_cursor, sqlid
 
 
 def _to_xlsx(db, dbtype, table, filename, header):
@@ -10,14 +9,14 @@ def _to_xlsx(db, dbtype, table, filename, header):
     width = []
     cur = db.cursor()
     try:
-        cur.execute('SELECT * FROM ' + sqlid(table) + ' LIMIT 1')
+        cur.execute("SELECT * FROM " + sqlid(table) + " LIMIT 1")
         for a in cur.description:
             attrs.append((a[0], a[1]))
             width.append(len(a[0]))
     finally:
         cur.close()
-    cols = ','.join([sqlid(a[0]) for a in attrs])
-    query = 'SELECT ' + cols + ' FROM ' + sqlid(table) + ' ORDER BY ' + ','.join(
+    cols = ",".join([sqlid(a[0]) for a in attrs])
+    query = "SELECT " + cols + " FROM " + sqlid(table) + " ORDER BY " + ",".join(
         [str(i + 1) for i in range(len(attrs))])
     # Scan
     cur = server_cursor(db, dbtype)
@@ -28,21 +27,20 @@ def _to_xlsx(db, dbtype, table, filename, header):
             if row is None:
                 break
             for i, data in enumerate(row):
-                lines = ['']
+                lines = [""]
                 if data is not None:
                     lines = str(data).splitlines()
                 for j, l in enumerate(lines):
                     len_l = len(l)
-                    if len_l > width[i]:
-                        width[i] = len_l
+                    width[i] = max(width[i], len_l)
     finally:
         cur.close()
     # Write data
     cur = server_cursor(db, dbtype)
     try:
         cur.execute(query)
-        fn = filename if '.' in filename else filename + '.xlsx'
-        workbook = xlsxwriter.Workbook(fn, {'constant_memory': True})
+        fn = filename if "." in filename else filename + ".xlsx"
+        workbook = xlsxwriter.Workbook(fn, {"constant_memory": True})
         try:
             worksheet = workbook.add_worksheet()
             for i, w in enumerate(width):
@@ -52,11 +50,11 @@ def _to_xlsx(db, dbtype, table, filename, header):
                 for i, a in enumerate(attrs):
                     fmt = workbook.add_format()
                     fmt.set_bold()
-                    fmt.set_align('center')
+                    fmt.set_align("center")
                     worksheet.write(0, i, a[0], fmt)
             row_i = 1 if header else 0
             datafmt = workbook.add_format()
-            datafmt.set_align('top')
+            datafmt.set_align("top")
             while True:
                 row = cur.fetchone()
                 if row is None:

--- a/src/ldlite/_xlsx.py
+++ b/src/ldlite/_xlsx.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 import xlsxwriter
 
-from ._sqlx import server_cursor, sqlid
+from ._sqlx import DBType, server_cursor, sqlid
 
 
-def _to_xlsx(db, dbtype, table, filename, header):
+def to_xlsx(db: Any, dbtype: DBType, table: str, filename: str, header: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
     # Read attributes
     attrs = []
     width = []
@@ -30,9 +32,8 @@ def _to_xlsx(db, dbtype, table, filename, header):
                 lines = [""]
                 if data is not None:
                     lines = str(data).splitlines()
-                for j, l in enumerate(lines):
-                    len_l = len(l)
-                    width[i] = max(width[i], len_l)
+                for _, ln in enumerate(lines):
+                    width[i] = max(width[i], len(ln))
     finally:
         cur.close()
     # Write data

--- a/src/ldlite/_xlsx.py
+++ b/src/ldlite/_xlsx.py
@@ -5,7 +5,9 @@ import xlsxwriter
 from ._sqlx import DBType, server_cursor, sqlid
 
 
-def to_xlsx(db: Any, dbtype: DBType, table: str, filename: str, header: list[str]) -> None:  # noqa: C901, PLR0912, PLR0915
+def to_xlsx(  # noqa: C901, PLR0912, PLR0915
+    db: Any, dbtype: DBType, table: str, filename: str, header: list[str]
+) -> None:
     # Read attributes
     attrs = []
     width = []
@@ -18,8 +20,14 @@ def to_xlsx(db: Any, dbtype: DBType, table: str, filename: str, header: list[str
     finally:
         cur.close()
     cols = ",".join([sqlid(a[0]) for a in attrs])
-    query = "SELECT " + cols + " FROM " + sqlid(table) + " ORDER BY " + ",".join(
-        [str(i + 1) for i in range(len(attrs))])
+    query = (
+        "SELECT "
+        + cols
+        + " FROM "
+        + sqlid(table)
+        + " ORDER BY "
+        + ",".join([str(i + 1) for i in range(len(attrs))])
+    )
     # Scan
     cur = server_cursor(db, dbtype)
     try:

--- a/src/ldlite/_xlsx.py
+++ b/src/ldlite/_xlsx.py
@@ -1,7 +1,7 @@
 import xlsxwriter
 
-from ._sqlx import _server_cursor
-from ._sqlx import _sqlid
+from ._sqlx import server_cursor
+from ._sqlx import sqlid
 
 
 def _to_xlsx(db, dbtype, table, filename, header):
@@ -10,17 +10,17 @@ def _to_xlsx(db, dbtype, table, filename, header):
     width = []
     cur = db.cursor()
     try:
-        cur.execute('SELECT * FROM ' + _sqlid(table) + ' LIMIT 1')
+        cur.execute('SELECT * FROM ' + sqlid(table) + ' LIMIT 1')
         for a in cur.description:
             attrs.append((a[0], a[1]))
             width.append(len(a[0]))
     finally:
         cur.close()
-    cols = ','.join([_sqlid(a[0]) for a in attrs])
-    query = 'SELECT ' + cols + ' FROM ' + _sqlid(table) + ' ORDER BY ' + ','.join(
+    cols = ','.join([sqlid(a[0]) for a in attrs])
+    query = 'SELECT ' + cols + ' FROM ' + sqlid(table) + ' ORDER BY ' + ','.join(
         [str(i + 1) for i in range(len(attrs))])
     # Scan
-    cur = _server_cursor(db, dbtype)
+    cur = server_cursor(db, dbtype)
     try:
         cur.execute(query)
         while True:
@@ -38,7 +38,7 @@ def _to_xlsx(db, dbtype, table, filename, header):
     finally:
         cur.close()
     # Write data
-    cur = _server_cursor(db, dbtype)
+    cur = server_cursor(db, dbtype)
     try:
         cur.execute(query)
         fn = filename if '.' in filename else filename + '.xlsx'

--- a/src/ldlite/_xlsx.py
+++ b/src/ldlite/_xlsx.py
@@ -6,7 +6,7 @@ from ._sqlx import DBType, server_cursor, sqlid
 
 
 def to_xlsx(  # noqa: C901, PLR0912, PLR0915
-    db: Any, dbtype: DBType, table: str, filename: str, header: list[str]
+    db: Any, dbtype: DBType, table: str, filename: str, header: bool
 ) -> None:
     # Read attributes
     attrs = []

--- a/tests/query/expansion_cases.py
+++ b/tests/query/expansion_cases.py
@@ -15,7 +15,7 @@ class QueryCase:
     expected_tables: list[str]
     expected_values: dict[str, tuple[list[str], list[tuple[Any, ...]]]]
 
-    def patch__request_get(self, _request_get_mock: MagicMock) -> None:
+    def patch_request_get(self, _request_get_mock: MagicMock) -> None:
         total_mock = MagicMock()
         total_mock.status_code = 200
         total_mock.json.return_value = {}

--- a/tests/query/test_duckdb.py
+++ b/tests/query/test_duckdb.py
@@ -7,13 +7,13 @@ from pytest_cases import parametrize_with_cases
 from .expansion_cases import QueryCase, QueryTestCases
 
 
-@mock.patch("ldlite._request_get")
+@mock.patch("ldlite.request_get")
 @parametrize_with_cases("tc", cases=QueryTestCases)
 def test_duckdb(request_get_mock: MagicMock, tc: QueryCase) -> None:
     from ldlite import LDLite as uut
 
     dsn = f":memory:{tc.db}"
-    tc.patch__request_get(request_get_mock)
+    tc.patch_request_get(request_get_mock)
 
     ld = uut()
 

--- a/tests/query/test_postgres.py
+++ b/tests/query/test_postgres.py
@@ -32,7 +32,7 @@ def pg_dsn(pytestconfig: pytest.Config) -> None | Callable[[str], str]:
     return setup
 
 
-@mock.patch("ldlite._request_get")
+@mock.patch("ldlite.request_get")
 @parametrize_with_cases("tc", cases=QueryTestCases)
 def test_postgres(
     request_get_mock: MagicMock, pg_dsn: None | Callable[[str], str], tc: QueryCase
@@ -43,7 +43,7 @@ def test_postgres(
     from ldlite import LDLite as uut
 
     dsn = pg_dsn(tc.db)
-    tc.patch__request_get(request_get_mock)
+    tc.patch_request_get(request_get_mock)
 
     ld = uut()
 

--- a/tests/query/test_sqlite.py
+++ b/tests/query/test_sqlite.py
@@ -8,13 +8,13 @@ from pytest_cases import parametrize_with_cases
 from .expansion_cases import QueryCase, QueryTestCases
 
 
-@mock.patch("ldlite._request_get")
+@mock.patch("ldlite.request_get")
 @parametrize_with_cases("tc", cases=QueryTestCases)
 def test_sqlite(request_get_mock: MagicMock, tc: QueryCase) -> None:
     from ldlite import LDLite as uut
 
     dsn = f"file:{tc.db}?mode=memory&cache=shared"
-    tc.patch__request_get(request_get_mock)
+    tc.patch_request_get(request_get_mock)
 
     ld = uut()
     # _check_okapi() hack


### PR DESCRIPTION
This PR has no changes to behavior. All rules for the Ruff linter have been enabled as well as using the Ruff formatter. There were a small number of Ruff lint rules that had to be turned off in the following categories:
* Complexity and performance issues that would require bigger refactors
* String concatenation because, for now, it's ddl manipulation

I was going to make mypy happy in this PR as well but it was already getting huge.
