### PR TITLE
Strictly type the main library

### DIFF
--- a/examples/folio_demo.py
+++ b/examples/folio_demo.py
@@ -1,4 +1,5 @@
 # This script uses LDLite to extract sample data from the FOLIO demo sites.
+from __future__ import annotations
 
 import sys
 
@@ -24,20 +25,20 @@ selected_site = okapi_snapshot
 ld = ldlite.LDLite()
 if selected_site == okapi_snapshot:
     ld.connect_okapi(
-        url=selected_site, tenant="diku", user="diku_admin", password="admin"
+        url=selected_site, tenant="diku", user="diku_admin", password="admin",
     )
 else:
     ld.connect_folio(
-        url=selected_site, tenant="diku", user="diku_admin", password="admin"
+        url=selected_site, tenant="diku", user="diku_admin", password="admin",
     )
 
-db = ld.connect_db(filename="ldlite.db")
+ld.connect_db(filename="ldlite.db")
 # For PostgreSQL, use connect_db_postgresql() instead of connect_db():
-# db = ld.connect_db_postgresql(dsn='dbname=ldlite host=localhost user=ldlite')
+# ld.connect_db_postgresql(dsn='dbname=ldlite host=localhost user=ldlite')
 
 allrec = "cql.allRecords=1 sortby id"
 
-queries = [
+queries: list[tuple[str, ...] | tuple[str, str, object, int]] = [
     ("folio_agreements.entitlement", "/erm/entitlements", allrec),
     ("folio_agreements.erm_resource", "/erm/resource", allrec),
     ("folio_agreements.org", "/erm/org", allrec),
@@ -227,14 +228,15 @@ queries = [
     ("folio_users.users", "/users", allrec),
 ]
 
-tables = []
+tables: list[str] = []
 for q in queries:
     try:
         if len(q) == 4:
-            t = ld.query(table=q[0], path=q[1], query=q[2], json_depth=q[3])
+            tables += ld.query(
+                table=q[0], path=q[1], query=str(q[2]), json_depth=int(q[3]),
+            )
         else:
-            t = ld.query(table=q[0], path=q[1], query=q[2])
-        tables += t
+            tables += ld.query(table=q[0], path=q[1], query=str(q[2]))
     except (ValueError, RuntimeError) as e:
         print(
             'folio_demo.py: error processing "' + str(q[1]) + '": ' + str(e),

--- a/examples/folio_demo.py
+++ b/examples/folio_demo.py
@@ -25,11 +25,17 @@ selected_site = okapi_snapshot
 ld = ldlite.LDLite()
 if selected_site == okapi_snapshot:
     ld.connect_okapi(
-        url=selected_site, tenant="diku", user="diku_admin", password="admin",
+        url=selected_site,
+        tenant="diku",
+        user="diku_admin",
+        password="admin",
     )
 else:
     ld.connect_folio(
-        url=selected_site, tenant="diku", user="diku_admin", password="admin",
+        url=selected_site,
+        tenant="diku",
+        user="diku_admin",
+        password="admin",
     )
 
 ld.connect_db(filename="ldlite.db")
@@ -233,7 +239,10 @@ for q in queries:
     try:
         if len(q) == 4:
             tables += ld.query(
-                table=q[0], path=q[1], query=str(q[2]), json_depth=int(q[3]),
+                table=q[0],
+                path=q[1],
+                query=str(q[2]),
+                json_depth=int(q[3]),
             )
         else:
             tables += ld.query(table=q[0], path=q[1], query=str(q[2]))

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "lint", "test"]
+groups = ["default", "lint", "test", "types"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:a398a565547d7e0347fcfe793eb84d96a8b9a90d14bea6deb41be4cbb27ae9b3"
+content_hash = "sha256:5f678b57d5afecf12c1b6da9b13fca6d5b4e2695a592182c50f78da9c4c55180"
 
 [[metadata.targets]]
 requires_python = ">=3.7,<3.10"
@@ -428,29 +428,29 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.11.9"
+version = "0.11.12"
 requires_python = ">=3.7"
 summary = "An extremely fast Python linter and code formatter, written in Rust."
 groups = ["lint"]
 files = [
-    {file = "ruff-0.11.9-py3-none-linux_armv6l.whl", hash = "sha256:a31a1d143a5e6f499d1fb480f8e1e780b4dfdd580f86e05e87b835d22c5c6f8c"},
-    {file = "ruff-0.11.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:66bc18ca783b97186a1f3100e91e492615767ae0a3be584e1266aa9051990722"},
-    {file = "ruff-0.11.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bd576cd06962825de8aece49f28707662ada6a1ff2db848d1348e12c580acbf1"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1d18b4be8182cc6fddf859ce432cc9631556e9f371ada52f3eaefc10d878de"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0f3f46f759ac623e94824b1e5a687a0df5cd7f5b00718ff9c24f0a894a683be7"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f34847eea11932d97b521450cf3e1d17863cfa5a94f21a056b93fb86f3f3dba2"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f33b15e00435773df97cddcd263578aa83af996b913721d86f47f4e0ee0ff271"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b27613a683b086f2aca8996f63cb3dd7bc49e6eccf590563221f7b43ded3f65"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e0d88756e63e8302e630cee3ce2ffb77859797cc84a830a24473939e6da3ca6"},
-    {file = "ruff-0.11.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:537c82c9829d7811e3aa680205f94c81a2958a122ac391c0eb60336ace741a70"},
-    {file = "ruff-0.11.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:440ac6a7029f3dee7d46ab7de6f54b19e34c2b090bb4f2480d0a2d635228f381"},
-    {file = "ruff-0.11.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:71c539bac63d0788a30227ed4d43b81353c89437d355fdc52e0cda4ce5651787"},
-    {file = "ruff-0.11.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c67117bc82457e4501473c5f5217d49d9222a360794bfb63968e09e70f340abd"},
-    {file = "ruff-0.11.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e4b78454f97aa454586e8a5557facb40d683e74246c97372af3c2d76901d697b"},
-    {file = "ruff-0.11.9-py3-none-win32.whl", hash = "sha256:7fe1bc950e7d7b42caaee2a8a3bc27410547cc032c9558ee2e0f6d3b209e845a"},
-    {file = "ruff-0.11.9-py3-none-win_amd64.whl", hash = "sha256:52edaa4a6d70f8180343a5b7f030c7edd36ad180c9f4d224959c2d689962d964"},
-    {file = "ruff-0.11.9-py3-none-win_arm64.whl", hash = "sha256:bcf42689c22f2e240f496d0c183ef2c6f7b35e809f12c1db58f75d9aa8d630ca"},
-    {file = "ruff-0.11.9.tar.gz", hash = "sha256:ebd58d4f67a00afb3a30bf7d383e52d0e036e6195143c6db7019604a05335517"},
+    {file = "ruff-0.11.12-py3-none-linux_armv6l.whl", hash = "sha256:c7680aa2f0d4c4f43353d1e72123955c7a2159b8646cd43402de6d4a3a25d7cc"},
+    {file = "ruff-0.11.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2cad64843da9f134565c20bcc430642de897b8ea02e2e79e6e02a76b8dcad7c3"},
+    {file = "ruff-0.11.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9b6886b524a1c659cee1758140138455d3c029783d1b9e643f3624a5ee0cb0aa"},
+    {file = "ruff-0.11.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cc3a3690aad6e86c1958d3ec3c38c4594b6ecec75c1f531e84160bd827b2012"},
+    {file = "ruff-0.11.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f97fdbc2549f456c65b3b0048560d44ddd540db1f27c778a938371424b49fe4a"},
+    {file = "ruff-0.11.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:74adf84960236961090e2d1348c1a67d940fd12e811a33fb3d107df61eef8fc7"},
+    {file = "ruff-0.11.12-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b56697e5b8bcf1d61293ccfe63873aba08fdbcbbba839fc046ec5926bdb25a3a"},
+    {file = "ruff-0.11.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d47afa45e7b0eaf5e5969c6b39cbd108be83910b5c74626247e366fd7a36a13"},
+    {file = "ruff-0.11.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bf9603fe1bf949de8b09a2da896f05c01ed7a187f4a386cdba6760e7f61be"},
+    {file = "ruff-0.11.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08033320e979df3b20dba567c62f69c45e01df708b0f9c83912d7abd3e0801cd"},
+    {file = "ruff-0.11.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:929b7706584f5bfd61d67d5070f399057d07c70585fa8c4491d78ada452d3bef"},
+    {file = "ruff-0.11.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7de4a73205dc5756b8e09ee3ed67c38312dce1aa28972b93150f5751199981b5"},
+    {file = "ruff-0.11.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2635c2a90ac1b8ca9e93b70af59dfd1dd2026a40e2d6eebaa3efb0465dd9cf02"},
+    {file = "ruff-0.11.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:d05d6a78a89166f03f03a198ecc9d18779076ad0eec476819467acb401028c0c"},
+    {file = "ruff-0.11.12-py3-none-win32.whl", hash = "sha256:f5a07f49767c4be4772d161bfc049c1f242db0cfe1bd976e0f0886732a4765d6"},
+    {file = "ruff-0.11.12-py3-none-win_amd64.whl", hash = "sha256:5a4d9f8030d8c3a45df201d7fb3ed38d0219bccd7955268e863ee4a115fa0832"},
+    {file = "ruff-0.11.12-py3-none-win_arm64.whl", hash = "sha256:65194e37853158d368e333ba282217941029a28ea90913c67e558c611d04daa5"},
+    {file = "ruff-0.11.12.tar.gz", hash = "sha256:43cf7f69c7d7c7d7513b9d59c5d8cafd704e05944f978614aa9faff6ac202603"},
 ]
 
 [[package]]
@@ -527,10 +527,45 @@ name = "types-psycopg2"
 version = "2.9.21.20"
 requires_python = ">=3.7"
 summary = "Typing stubs for psycopg2"
-groups = ["lint"]
+groups = ["types"]
 files = [
     {file = "types-psycopg2-2.9.21.20.tar.gz", hash = "sha256:73baea689575bf5bb1b915b783fb0524044c6242928aeef1ae5a9e32f0780d3d"},
     {file = "types_psycopg2-2.9.21.20-py3-none-any.whl", hash = "sha256:5b1e2e1d9478f8a298ea7038f8ea988e0ccc1f0af39f84636d57ef0da6f29e95"},
+]
+
+[[package]]
+name = "types-requests"
+version = "2.31.0.6"
+requires_python = ">=3.7"
+summary = "Typing stubs for requests"
+groups = ["types"]
+dependencies = [
+    "types-urllib3",
+]
+files = [
+    {file = "types-requests-2.31.0.6.tar.gz", hash = "sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0"},
+    {file = "types_requests-2.31.0.6-py3-none-any.whl", hash = "sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9"},
+]
+
+[[package]]
+name = "types-tqdm"
+version = "4.66.0.5"
+requires_python = ">=3.7"
+summary = "Typing stubs for tqdm"
+groups = ["types"]
+files = [
+    {file = "types-tqdm-4.66.0.5.tar.gz", hash = "sha256:74bd7e469238c28816300f72a9b713d02036f6b557734616430adb7b7e74112c"},
+    {file = "types_tqdm-4.66.0.5-py3-none-any.whl", hash = "sha256:d2c38085bec440e8ad1e94e8619f7cb3d1dd0a7ee06a863ccd0610a5945046ef"},
+]
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.25.14"
+summary = "Typing stubs for urllib3"
+groups = ["types"]
+files = [
+    {file = "types-urllib3-1.26.25.14.tar.gz", hash = "sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f"},
+    {file = "types_urllib3-1.26.25.14-py3-none-any.whl", hash = "sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 "tests/*" = ["D", "S", "INP001", "N813"]
-"src/ldlite/{__init__.py,_jsonx.py,_xlsx.py}" = ["ANN401"]
+"src/ldlite/{__init__.py,_jsonx.py}" = ["ANN401"]
 "src/ldlite/{_csv.py,_jsonx.py,_select.py,_xlsx.py}" = ["S608"]
 "src/ldlite/__init__.py" = ["T201"]
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,12 @@ target-version = "py39"
 [tool.ruff.lint]
 select = ["ALL"]
 fixable = ["ALL"]
-ignore = ["FBT", "ANN401", "D105", "FIX002", "PLR2004", "TD002", "TD003", "COM812"]
+ignore = ["FBT", "D105", "FIX002", "PLR2004", "TD002", "TD003", "COM812"]
 pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 "tests/*" = ["D", "S", "INP001", "N813"]
+"src/ldlite/{__init__.py,_csv.py,_jsonx.py,_xlsx.py}" = ["ANN401"]
 "src/ldlite/{_csv.py,_jsonx.py,_select.py,_xlsx.py}" = ["S608"]
 "src/ldlite/__init__.py" = ["T201"]
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 "tests/*" = ["D", "S", "INP001", "N813"]
-"src/ldlite/{__init__.py,_csv.py,_jsonx.py,_xlsx.py}" = ["ANN401"]
+"src/ldlite/{__init__.py,_jsonx.py,_xlsx.py}" = ["ANN401"]
 "src/ldlite/{_csv.py,_jsonx.py,_select.py,_xlsx.py}" = ["S608"]
 "src/ldlite/__init__.py" = ["T201"]
 [tool.ruff.lint.flake8-annotations]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,8 @@ pydocstyle.convention = "google"
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 "tests/*" = ["D", "S", "INP001", "N813"]
-"src/ldlite/{__init__.py,_jsonx.py}" = ["ANN401"]
 "src/ldlite/{_csv.py,_jsonx.py,_select.py,_xlsx.py}" = ["S608"]
-"src/ldlite/__init__.py" = ["T201"]
+"src/ldlite/__init__.py" = ["T201", "ANN401"]
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ pydocstyle.convention = "google"
 "examples/*" = ["D", "INP001", "T201", "S106", "ERA001", "PERF203"]
 "tests/*" = ["D", "S", "INP001", "N813"]
 "src/ldlite/{_csv.py,_jsonx.py,_select.py,_xlsx.py}" = ["S608"]
-"src/ldlite/__init__.py" = ["T201", "ANN401"]
+"src/ldlite/__init__.py" = ["T201"]
 [tool.ruff.lint.flake8-annotations]
 mypy-init-return = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ addopts = [
 [tool.mypy]
 python_version = "3.9"
 strict = true
+[[tool.mypy.overrides]]
+module = ["xlsxwriter.*"]
 ignore_missing_imports = true
-exclude = ["src"]
-
 
 [tool.ruff]
 target-version = "py39"
@@ -70,10 +70,14 @@ test = "python -m pytest -vv"
 lint = [
     "mypy>=1.4.1",
     "ruff>=0.11.9",
-    "types-psycopg2>=2.9.21.20",
 ]
 test = [
     "pytest>=7.4.4",
     "pytest-cases>=3.8.6",
+]
+types = [
+    "types-requests>=2.31.0.6",
+    "types-psycopg2>=2.9.21.20",
+    "types-tqdm>=4.66.0.5",
 ]
 

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -51,7 +51,7 @@ from ._jsonx import Attr, drop_json_tables, transform_json
 from ._query import query_dict
 from ._request import request_get
 from ._select import select
-from ._sqlx import DBType, DbConn, autocommit, encode_sql_str, json_type, sqlid
+from ._sqlx import DbConn, DBType, autocommit, encode_sql_str, json_type, sqlid
 from ._xlsx import to_xlsx
 
 

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -80,9 +80,9 @@ class LDLite:
         self.login_token: str | None = None
         self.legacy_auth = True
         self.okapi_url: str | None = None
-        self.okapi_tenant = None
-        self.okapi_user = None
-        self.okapi_password = None
+        self.okapi_tenant: str | None = None
+        self.okapi_user: str | None = None
+        self.okapi_password: str | None = None
         self._okapi_timeout = 60
         self._okapi_max_retries = 2
 
@@ -174,7 +174,10 @@ class LDLite:
     def _login(self) -> None:
         if self._verbose:
             print("ldlite: logging in to folio", file=sys.stderr)
-        hdr = {"X-Okapi-Tenant": self.okapi_tenant, "Content-Type": "application/json"}
+        hdr = {
+            "X-Okapi-Tenant": str(self.okapi_tenant),
+            "Content-Type": "application/json",
+        }
         data = {"username": self.okapi_user, "password": self.okapi_password}
 
         if self.okapi_url is None:
@@ -397,13 +400,13 @@ class LDLite:
             self.db.commit()
             # First get total number of records
             hdr = {
-                "X-Okapi-Tenant": self.okapi_tenant,
-                "X-Okapi-Token": self.login_token,
+                "X-Okapi-Tenant": str(self.okapi_tenant),
+                "X-Okapi-Token": str(self.login_token),
             }
             querycopy["offset"] = "0"
             querycopy["limit"] = "1"
             resp = request_get(
-                self.okapi_url + path,
+                str(self.okapi_url) + path,
                 params=querycopy,
                 headers=hdr,
                 timeout=self._okapi_timeout,
@@ -418,11 +421,11 @@ class LDLite:
                 # to allow for bigger internal changes.
                 self._login()
                 hdr = {
-                    "X-Okapi-Tenant": self.okapi_tenant,
-                    "X-Okapi-Token": self.login_token,
+                    "X-Okapi-Tenant": str(self.okapi_tenant),
+                    "X-Okapi-Token": str(self.login_token),
                 }
                 resp = request_get(
-                    self.okapi_url + path,
+                    str(self.okapi_url) + path,
                     params=querycopy,
                     headers=hdr,
                     timeout=self._okapi_timeout,
@@ -473,7 +476,7 @@ class LDLite:
                     querycopy["offset"] = str(offset)
                     querycopy["limit"] = str(lim)
                     resp = request_get(
-                        self.okapi_url + path,
+                        str(self.okapi_url) + path,
                         params=querycopy,
                         headers=hdr,
                         timeout=self._okapi_timeout,
@@ -483,11 +486,11 @@ class LDLite:
                         # See warning above for retries
                         self._login()
                         hdr = {
-                            "X-Okapi-Tenant": self.okapi_tenant,
-                            "X-Okapi-Token": self.login_token,
+                            "X-Okapi-Tenant": str(self.okapi_tenant),
+                            "X-Okapi-Token": str(self.login_token),
                         }
                         resp = request_get(
-                            self.okapi_url + path,
+                            str(self.okapi_url) + path,
                             params=querycopy,
                             headers=hdr,
                             timeout=self._okapi_timeout,

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -77,9 +77,9 @@ class LDLite:
             | sqlite3.Connection
             | None
         ) = None
-        self.login_token = None
+        self.login_token: str | None = None
         self.legacy_auth = True
-        self.okapi_url = None
+        self.okapi_url: str | None = None
         self.okapi_tenant = None
         self.okapi_user = None
         self.okapi_password = None

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -276,7 +276,7 @@ class LDLite:
             pass
         finally:
             cur.close()
-        drop_json_tables(self.db, self.dbtype, table)
+        drop_json_tables(self.db, table)
 
     def set_folio_max_retries(self, max_retries: int) -> None:
         """Sets the maximum number of retries for FOLIO requests.

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import sys
-from typing import TYPE_CHECKING, Any, NoReturn, cast
+from typing import TYPE_CHECKING, NoReturn, cast
 
 import duckdb
 import psycopg2
@@ -324,7 +324,7 @@ class LDLite:
         query: str | None = None,
         json_depth: int = 3,
         limit: int | None = None,
-        transform: Any = None,
+        transform: bool | None = None,
     ) -> list[str]:
         """Submits a query to a FOLIO module, and transforms and stores the result.
 

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -210,11 +210,10 @@ class LDLite:
             msg = "connection to folio not configured: use connect_folio()"
             raise RuntimeError(msg)
 
-    def _check_db(self) -> bool:
+    def _check_db(self) -> None:
         if self.db is None:
             msg = "no database connection: use connect_db() or connect_db_postgresql()"
             raise RuntimeError(msg)
-        return True
 
     def connect_folio(self, url: str, tenant: str, user: str, password: str) -> None:
         """Connects to a FOLIO instance with a user name and password.

--- a/src/ldlite/_csv.py
+++ b/src/ldlite/_csv.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING
 
 from ._sqlx import DBType, server_cursor, sqlid
+
+if TYPE_CHECKING:
+    from _typeshed import dbapi
 
 
 def _escape_csv(field: str) -> str:
@@ -16,13 +19,20 @@ def _escape_csv(field: str) -> str:
     return b
 
 
-def to_csv(db: Any, dbtype: DBType, table: str, filename: str, header: bool) -> None:
+def to_csv(
+    db: dbapi.DBAPIConnection,
+    dbtype: DBType,
+    table: str,
+    filename: str,
+    header: bool,
+) -> None:
     # Read attributes
-    attrs: list[tuple[str, str | Literal[20, 23]]] = []
+    attrs: list[tuple[str, dbapi.DBAPITypeCode]] = []
     cur = db.cursor()
     try:
         cur.execute("SELECT * FROM " + sqlid(table) + " LIMIT 1")
-        attrs.extend([(a[0], a[1]) for a in cur.description])
+        if cur.description is not None:
+            attrs.extend([(a[0], a[1]) for a in cur.description])
     finally:
         cur.close()
     # Write data
@@ -35,7 +45,7 @@ def to_csv(db: Any, dbtype: DBType, table: str, filename: str, header: bool) -> 
             + " FROM "
             + sqlid(table)
             + " ORDER BY "
-            + ",".join([str(i + 1) for i in range(len(attrs))])
+            + ",".join([str(i + 1) for i in range(len(attrs))]),
         )
         fn = Path(filename if "." in filename else filename + ".csv")
         with fn.open("w") as f:

--- a/src/ldlite/_csv.py
+++ b/src/ldlite/_csv.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from ._sqlx import DBType, server_cursor, sqlid
 
@@ -16,12 +18,11 @@ def _escape_csv(field: str) -> str:
 
 def to_csv(db: Any, dbtype: DBType, table: str, filename: str, header: bool) -> None:
     # Read attributes
-    attrs = []
+    attrs: list[tuple[str, str | Literal[20, 23]]] = []
     cur = db.cursor()
     try:
         cur.execute("SELECT * FROM " + sqlid(table) + " LIMIT 1")
-        for a in cur.description:
-            attrs.extend((a[0], a[1]))
+        attrs.extend([(a[0], a[1]) for a in cur.description])
     finally:
         cur.close()
     # Write data

--- a/src/ldlite/_jsonx.py
+++ b/src/ldlite/_jsonx.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
-from typing import Any, Literal, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 import duckdb
 import psycopg2
@@ -18,6 +18,9 @@ from ._sqlx import (
     sqlid,
     varchar_type,
 )
+
+if TYPE_CHECKING:
+    from _typeshed import dbapi
 
 JsonValue = Union[float, int, str, bool, "Json", list["JsonValue"], None]
 Json = dict[str, JsonValue]
@@ -38,7 +41,7 @@ class Attr:
         name: str,
         datatype: Literal["varchar", "integer", "numeric", "boolean", "uuid", "bigint"],
         order: None | Literal[1, 2, 3] = None,
-        data: Any = None,
+        data: JsonValue = None,
     ):
         self.name = name
         self.datatype: Literal[
@@ -92,7 +95,7 @@ def _tcatalog(table: str) -> str:
 
 
 # noinspection DuplicatedCode
-def _old_drop_json_tables(db: Any, table: str) -> None:
+def _old_drop_json_tables(db: dbapi.DBAPIConnection, table: str) -> None:
     jtable_sql = sqlid(_old_jtable(table))
     cur = db.cursor()
     try:
@@ -128,7 +131,7 @@ def _old_drop_json_tables(db: Any, table: str) -> None:
 
 
 # noinspection DuplicatedCode
-def drop_json_tables(db: Any, table: str) -> None:
+def drop_json_tables(db: dbapi.DBAPIConnection, table: str) -> None:
     tcatalog_sql = sqlid(_tcatalog(table))
     cur = db.cursor()
     try:
@@ -301,7 +304,7 @@ def _compile_attrs(  # noqa: C901, PLR0912, PLR0913
 def _transform_array_data(  # noqa: PLR0913
     dbtype: DBType,
     prefix: str,
-    cur: Any,
+    cur: dbapi.DBAPICursor,
     parents: list[tuple[int, str]],
     jarray: list[JsonValue],
     newattrs: dict[str, dict[str, Attr]],
@@ -364,7 +367,7 @@ def _transform_array_data(  # noqa: PLR0913
 def _compile_data(  # noqa: C901, PLR0912, PLR0913
     dbtype: DBType,
     prefix: str,
-    cur: Any,
+    cur: dbapi.DBAPICursor,
     parents: list[tuple[int, str]],
     jdict: Json,
     newattrs: dict[str, dict[str, Attr]],
@@ -372,12 +375,12 @@ def _compile_data(  # noqa: C901, PLR0912, PLR0913
     row_ids: dict[str, int],
     max_depth: int,
     quasikey: dict[str, Attr],
-) -> None | list[tuple[str, Any]]:
+) -> None | list[tuple[str, JsonValue]]:
     if depth > max_depth:
         return None
     table = _table_name(parents)
     qkey = {k: quasikey[k] for k in quasikey}
-    row: list[tuple[str, Any]] = []
+    row: list[tuple[str, JsonValue]] = []
     arrays = []
     objects = []
     for k, v in jdict.items():
@@ -438,7 +441,7 @@ def _compile_data(  # noqa: C901, PLR0912, PLR0913
 def _transform_data(  # noqa: PLR0913
     dbtype: DBType,
     prefix: str,
-    cur: Any,
+    cur: dbapi.DBAPICursor,
     parents: list[tuple[int, str]],
     jdict: Json,
     newattrs: dict[str, dict[str, Attr]],
@@ -478,7 +481,7 @@ def _transform_data(  # noqa: PLR0913
 
 
 def transform_json(  # noqa: C901, PLR0912, PLR0913, PLR0915
-    db: Any,
+    db: dbapi.DBAPIConnection,
     dbtype: DBType,
     table: str,
     total: int,
@@ -487,18 +490,19 @@ def transform_json(  # noqa: C901, PLR0912, PLR0913, PLR0915
 ) -> tuple[list[str], dict[str, dict[str, Attr]]]:
     # Scan all fields for JSON data
     # First get a list of the string attributes
-    str_attrs = []
+    str_attrs: list[str] = []
     cur = db.cursor()
     try:
         cur.execute("SELECT * FROM " + sqlid(table) + " LIMIT 1")
-        str_attrs.extend([a[0] for a in cur.description])
+        if cur.description is not None:
+            str_attrs.extend([a[0] for a in cur.description])
     finally:
         cur.close()
     # Scan data for JSON objects
     if len(str_attrs) == 0:
         return [], {}
-    json_attrs = []
-    json_attrs_set = set()
+    json_attrs: list[str] = []
+    json_attrs_set: set[str] = set()
     newattrs: dict[str, dict[str, Attr]] = {}
     cur = server_cursor(db, dbtype)
     try:

--- a/src/ldlite/_select.py
+++ b/src/ldlite/_select.py
@@ -28,7 +28,7 @@ def _maxlen(lines: list[str]) -> int:
 
 
 def _rstrip_lines(lines: list[str]) -> list[str]:
-    newlines = []
+    newlines: list[str] = []
     for s in lines:
         newlines.extend(s.rstrip())
     return newlines

--- a/src/ldlite/_sqlx.py
+++ b/src/ldlite/_sqlx.py
@@ -28,29 +28,36 @@ DbCursor = Union[
     sqlite3.Cursor,
 ]
 
+
 def as_duckdb(
-    db: DbConn, dbtype: DBType,
+    db: DbConn,
+    dbtype: DBType,
 ) -> duckdb.DuckDBPyConnection | None:
     if dbtype != DBType.DUCKDB:
         return None
 
     return cast("duckdb.DuckDBPyConnection", db)
 
+
 def as_postgres(
-    db: DbConn, dbtype: DBType,
+    db: DbConn,
+    dbtype: DBType,
 ) -> psycopg2.extensions.connection | None:
     if dbtype != DBType.POSTGRES:
         return None
 
     return cast("psycopg2.extensions.connection", db)
 
+
 def as_sqlite(
-    db: DbConn, dbtype: DBType,
+    db: DbConn,
+    dbtype: DBType,
 ) -> sqlite3.Connection | None:
     if dbtype != DBType.SQLITE:
         return None
 
     return cast("sqlite3.Connection", db)
+
 
 def strip_schema(table: str) -> str:
     st = table.split(".")

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -12,6 +12,6 @@ class TestLDLite(TestCase):
             user="diku_admin",
             password="admin",
         )
-        _ = ld.connect_db()
-        _ = ld.query(table="g", path="/groups", query="cql.allRecords=1 sortby id")
+        ld.connect_db()
+        ld.query(table="g", path="/groups", query="cql.allRecords=1 sortby id")
         ld.select(table="g__t")


### PR DESCRIPTION
Mypy was disabled for the main library. This enables it and also makes ruff warn on Any type annotations. I relied on Any and Unknown quite a bit to make ruff happy while linting and this PR introduces a number of types to replace the Any type. For the most part there _should_ be no behavior changes with two exceptions:
* drop_json_tables method was broken for all dbs
* uuid columns were broken for postgres 

Indices on postgres remain broken because it is a much bigger behavior change.