### PR TITLE
Final cleanup changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+### Commits to bring in typing, linting, and formatting ###
+48d70aea77b99b23ff93c62d5d0af22e2c1e4ef1
+d699f3575113b42e6943c6a2c0e9d739052ec321
+b48aad82200a8d457e59ccb9492ed75bb7431e85
+###

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema: https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+---
+name: Lint
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - review_requested
+      - ready_for_review
+      - auto_merge_enabled
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # install dependencies
+      - uses: pdm-project/setup-pdm@v4
+        with:
+          cache: true
+      - run: pdm install -G:all
+      - uses: jaxxstorm/action-install-gh-release@v1.10.0
+        with:
+          repo: houseabsolute/precious
+          tag: v0.9.0
+          cache: enable
+
+      # lint
+      - run: pdm run precious lint --all
+      - run: |
+          set -eoux pipefail
+
+          pdm run precious tidy --all
+          git diff --exit-code
+        if: success() || failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema: https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/github-workflow.json
+---
+name: Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - opened
+      - review_requested
+      - ready_for_review
+      - auto_merge_enabled
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # install dependencies
+      - uses: pdm-project/setup-pdm@v4
+        with:
+          cache: true
+      - run: pdm install -G test
+
+      # test
+      - run: pdm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+!precious.toml
 ldlite.db
 ldlite.db.wal
 
@@ -6,4 +7,3 @@ dist
 ldlite.egg-info
 tmp
 .idea
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,1 @@
 Pull requests are not currently accepted for this project.
-

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ tables: g, g__t, g__tcatalog
 ```
 
 ```
- __id |                  id                  |         desc          | expiration_offset_in_days |   group   
+ __id |                  id                  |         desc          | expiration_offset_in_days |   group  
 ------+--------------------------------------+-----------------------+---------------------------+-----------
-    1 | 3684a786-6671-4268-8ed0-9db82ebca60b | Staff Member          |                       730 | staff     
-    2 | 503a81cd-6c26-400f-b620-14c08943697c | Faculty Member        |                       365 | faculty   
+    1 | 3684a786-6671-4268-8ed0-9db82ebca60b | Staff Member          |                       730 | staff  
+    2 | 503a81cd-6c26-400f-b620-14c08943697c | Faculty Member        |                       365 | faculty  
     3 | ad0bc554-d5bc-463c-85d1-5562127ae91b | Graduate Student      |                           | graduate  
-    4 | bdc2b6d4-5ceb-4a12-ab46-249b9a68473e | Undergraduate Student |                           | undergrad 
+    4 | bdc2b6d4-5ceb-4a12-ab46-249b9a68473e | Undergraduate Student |                           | undergrad
 (4 rows)
 ```
 
@@ -114,4 +114,3 @@ Other resources
 * [FOLIO API documentation](https://dev.folio.org/reference/api/)
 
 * [Python learning resources](https://www.python.org/about/gettingstarted/)
-

--- a/environment.yaml
+++ b/environment.yaml
@@ -7,3 +7,4 @@ dependencies:
   - python>=3.7,<3.10
   - pdm==2.24.1
   - postgresql==17.5
+  - precious==0.9.0

--- a/examples/example.md
+++ b/examples/example.md
@@ -48,46 +48,46 @@ _ = ld.query(table='g', path='/groups', query='cql.allRecords=1 sortby id')
 ld.select(table='g', limit=10)
 ```
 
-     __id |                          jsonb                          
+     __id |                          jsonb  
     ------+---------------------------------------------------------
-        1 | { 
-          |     "group": "staff", 
-          |     "desc": "Staff Member", 
-          |     "id": "3684a786-6671-4268-8ed0-9db82ebca60b", 
-          |     "expirationOffsetInDays": 730, 
-          |     "metadata": { 
-          |         "createdDate": "2021-09-20T01:53:31.055+00:00", 
-          |         "updatedDate": "2021-09-20T01:53:31.055+00:00" 
-          |     } 
-          | } 
-        2 | { 
-          |     "group": "faculty", 
-          |     "desc": "Faculty Member", 
-          |     "id": "503a81cd-6c26-400f-b620-14c08943697c", 
-          |     "expirationOffsetInDays": 365, 
-          |     "metadata": { 
-          |         "createdDate": "2021-09-20T01:53:31.084+00:00", 
-          |         "updatedDate": "2021-09-20T01:53:31.084+00:00" 
-          |     } 
-          | } 
-        3 | { 
-          |     "group": "graduate", 
-          |     "desc": "Graduate Student", 
-          |     "id": "ad0bc554-d5bc-463c-85d1-5562127ae91b", 
-          |     "metadata": { 
-          |         "createdDate": "2021-09-20T01:53:31.108+00:00", 
-          |         "updatedDate": "2021-09-20T01:53:31.108+00:00" 
-          |     } 
-          | } 
-        4 | { 
-          |     "group": "undergrad", 
-          |     "desc": "Undergraduate Student", 
-          |     "id": "bdc2b6d4-5ceb-4a12-ab46-249b9a68473e", 
-          |     "metadata": { 
-          |         "createdDate": "2021-09-20T01:53:31.123+00:00", 
-          |         "updatedDate": "2021-09-20T01:53:31.123+00:00" 
-          |     } 
-          | } 
+        1 | {
+          |     "group": "staff",
+          |     "desc": "Staff Member",
+          |     "id": "3684a786-6671-4268-8ed0-9db82ebca60b",
+          |     "expirationOffsetInDays": 730,
+          |     "metadata": {
+          |         "createdDate": "2021-09-20T01:53:31.055+00:00",
+          |         "updatedDate": "2021-09-20T01:53:31.055+00:00"
+          |     }
+          | }
+        2 | {
+          |     "group": "faculty",
+          |     "desc": "Faculty Member",
+          |     "id": "503a81cd-6c26-400f-b620-14c08943697c",
+          |     "expirationOffsetInDays": 365,
+          |     "metadata": {
+          |         "createdDate": "2021-09-20T01:53:31.084+00:00",
+          |         "updatedDate": "2021-09-20T01:53:31.084+00:00"
+          |     }
+          | }
+        3 | {
+          |     "group": "graduate",
+          |     "desc": "Graduate Student",
+          |     "id": "ad0bc554-d5bc-463c-85d1-5562127ae91b",
+          |     "metadata": {
+          |         "createdDate": "2021-09-20T01:53:31.108+00:00",
+          |         "updatedDate": "2021-09-20T01:53:31.108+00:00"
+          |     }
+          | }
+        4 | {
+          |     "group": "undergrad",
+          |     "desc": "Undergraduate Student",
+          |     "id": "bdc2b6d4-5ceb-4a12-ab46-249b9a68473e",
+          |     "metadata": {
+          |         "createdDate": "2021-09-20T01:53:31.123+00:00",
+          |         "updatedDate": "2021-09-20T01:53:31.123+00:00"
+          |     }
+          | }
     (4 rows)
 
 ```python
@@ -97,12 +97,12 @@ ld.select(table='g', limit=10)
 ld.select(table='g__t', limit=10)
 ```
 
-     __id |                  id                  |         desc          | expiration_offset_in_days |   group   
+     __id |                  id                  |         desc          | expiration_offset_in_days |   group  
     ------+--------------------------------------+-----------------------+---------------------------+-----------
-        1 | 3684a786-6671-4268-8ed0-9db82ebca60b | Staff Member          |                       730 | staff     
-        2 | 503a81cd-6c26-400f-b620-14c08943697c | Faculty Member        |                       365 | faculty   
+        1 | 3684a786-6671-4268-8ed0-9db82ebca60b | Staff Member          |                       730 | staff  
+        2 | 503a81cd-6c26-400f-b620-14c08943697c | Faculty Member        |                       365 | faculty  
         3 | ad0bc554-d5bc-463c-85d1-5562127ae91b | Graduate Student      |                           | graduate  
-        4 | bdc2b6d4-5ceb-4a12-ab46-249b9a68473e | Undergraduate Student |                           | undergrad 
+        4 | bdc2b6d4-5ceb-4a12-ab46-249b9a68473e | Undergraduate Student |                           | undergrad
     (4 rows)
 
 ```python
@@ -131,18 +131,18 @@ cur.execute("""
 ld.select(table='user_groups', limit=10)
 ```
 
-                      id                  | username |   group   
+                      id                  | username |   group  
     --------------------------------------+----------+-----------
-     00bc2807-4d5b-4a27-a2b5-b7b1ba431cc4 | sallie   | faculty   
-     011dc219-6b7f-4d93-ae7f-f512ed651493 | elmer    | staff     
+     00bc2807-4d5b-4a27-a2b5-b7b1ba431cc4 | sallie   | faculty  
+     011dc219-6b7f-4d93-ae7f-f512ed651493 | elmer    | staff  
      01b9d72b-9aab-4efd-97a4-d03c1667bf0d | rick1    | graduate  
-     0414af69-f89c-40f2-bea9-a9b5d0a179d4 | diana    | faculty   
-     046353cf-3963-482c-9792-32ade0a33afa | jorge    | faculty   
-     04e1cda1-a049-463b-97af-98c59a8fd806 | nicola   | undergrad 
+     0414af69-f89c-40f2-bea9-a9b5d0a179d4 | diana    | faculty  
+     046353cf-3963-482c-9792-32ade0a33afa | jorge    | faculty  
+     04e1cda1-a049-463b-97af-98c59a8fd806 | nicola   | undergrad
      066795ce-4938-48f2-9411-f3f922b51e1c | arlo     | graduate  
-     07066a1f-1fb7-4793-bbca-7cd8d1ea90ab | vergie   | faculty   
-     08522da4-668a-4450-a769-3abfae5678ad | johan    | staff     
-     0a246f61-d85f-42b6-8dcc-48d25a46690b | maxine   | staff     
+     07066a1f-1fb7-4793-bbca-7cd8d1ea90ab | vergie   | faculty  
+     08522da4-668a-4450-a769-3abfae5678ad | johan    | staff  
+     0a246f61-d85f-42b6-8dcc-48d25a46690b | maxine   | staff  
     (10 rows)
 
 ```python
@@ -190,5 +190,3 @@ _ = df.plot(kind='pie', x='user_group', y='count')
 ```
 
 ![png](output_14_1.png)
-    
-

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "lint", "test", "types"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5f678b57d5afecf12c1b6da9b13fca6d5b4e2695a592182c50f78da9c4c55180"
+content_hash = "sha256:32920cb12187858a40277bfec2731a330d741f05aa359026d978df8a4419a5ab"
 
 [[metadata.targets]]
 requires_python = ">=3.7,<3.10"
@@ -333,6 +333,21 @@ files = [
 ]
 
 [[package]]
+name = "pre-commit-hooks"
+version = "4.4.0"
+requires_python = ">=3.7"
+summary = "Some out-of-the-box hooks for pre-commit."
+groups = ["lint"]
+dependencies = [
+    "ruamel-yaml>=0.15",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+]
+files = [
+    {file = "pre_commit_hooks-4.4.0-py2.py3-none-any.whl", hash = "sha256:fc8837335476221ccccda3d176ed6ae29fe58753ce7e8b7863f5d0f987328fc6"},
+    {file = "pre_commit_hooks-4.4.0.tar.gz", hash = "sha256:7011eed8e1a25cde94693da009cba76392194cecc2f3f06c51a44ea6ad6c2af9"},
+]
+
+[[package]]
 name = "psycopg2"
 version = "2.9.5"
 requires_python = ">=3.6"
@@ -424,6 +439,55 @@ dependencies = [
 files = [
     {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},
     {file = "requests-2.28.2.tar.gz", hash = "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"},
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.18.12"
+requires_python = ">=3.7"
+summary = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+groups = ["lint"]
+dependencies = [
+    "ruamel-yaml-clib>=0.2.7; platform_python_implementation == \"CPython\" and python_version < \"3.14\"",
+]
+files = [
+    {file = "ruamel.yaml-0.18.12-py3-none-any.whl", hash = "sha256:790ba4c48b6a6e6b12b532a7308779eb12d2aaab3a80fdb8389216f28ea2b287"},
+    {file = "ruamel.yaml-0.18.12.tar.gz", hash = "sha256:5a38fd5ce39d223bebb9e3a6779e86b9427a03fb0bf9f270060f8b149cffe5e2"},
+]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.8"
+requires_python = ">=3.6"
+summary = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+groups = ["lint"]
+marker = "platform_python_implementation == \"CPython\" and python_version < \"3.14\""
+files = [
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl", hash = "sha256:75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl", hash = "sha256:955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl", hash = "sha256:84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl", hash = "sha256:25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"},
+    {file = "ruamel.yaml.clib-0.2.8.tar.gz", hash = "sha256:beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"},
 ]
 
 [[package]]

--- a/precious.toml
+++ b/precious.toml
@@ -1,0 +1,42 @@
+[commands."common.EOF"]
+type = "tidy"
+include = ["*"]
+exclude = ["*.png"]
+cmd = ["end-of-file-fixer"]
+ok_exit_codes = [0, 1]
+[commands."common.whitespace"]
+type = "tidy"
+include = ["*"]
+exclude = ["*.png"]
+cmd = ["trailing-whitespace-fixer", "--markdown-linebreak-ext=md"]
+ok_exit_codes = [0, 1]
+[commands."common.large-files"]
+type = "lint"
+include = ["*"]
+cmd = ["check-added-large-files"]
+ok_exit_codes = [0]
+[commands."common.case"]
+type = "lint"
+include = ["*"]
+cmd = ["check-case-conflict"]
+ok_exit_codes = [0]
+
+[commands."ruff.lint"]
+type = "both"
+include = ["*.py"]
+cmd = ["ruff", "check", "--quiet"]
+tidy_flags = ["--fix-only"]
+ok_exit_codes = [0]
+[commands."ruff.format"]
+type = "both"
+include = ["*.py"]
+cmd = ["ruff", "format", "--quiet"]
+lint_flags = ["--diff"]
+ok_exit_codes = [0]
+[commands.mypy]
+type = "lint"
+include = ["*.py"]
+invoke = "once"
+path_args = "none"
+cmd = ["mypy", "src/ldlite/", "tests/"]
+ok_exit_codes = [0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ test = "python -m pytest -vv"
 lint = [
     "mypy>=1.4.1",
     "ruff>=0.11.9",
+    "pre-commit-hooks>=4.4.0",
 ]
 test = [
     "pytest>=7.4.4",
@@ -80,4 +81,3 @@ types = [
     "types-psycopg2>=2.9.21.20",
     "types-tqdm>=4.66.0.5",
 ]
-


### PR DESCRIPTION
This PR configures a .git-blame-ignore-revs file to hide the three previous commits (which should have mostly no behavior changes) from git blame so it will be cleaner. For more information see: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view

Also, to make sure the repo continues to stay consistently typed/linted/formatted precious has been configured. There are new github workflows to run the code quality checks and tests. I'd like to have this run in CI but do not have the ability (currently) to modify the repo settings.