### PR TITLE
Deprecate sqlite and slsx functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 
 ### Added
 
+- Deprecation notice for xlsx and sqlite functionality. They will be removed in 4.0.
+
 ### Changed
 
 - Fixed endpoints that use with perPage instead of limit
@@ -18,6 +20,7 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 - Fixed `connect_db` method
 
 ### Removed
+
 
 ## [3.0.0] - July 2025
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tables: u, u__t, u__t__departments, u__t__personal__addresses, u__t__proxy_for, 
             FROM u__t
                 JOIN g__t ON u__t.patron_group = g__t.id;
         """)
->> > ld.export_excel(table='user_groups', filename='groups.xlsx')
+>> > ld.export_csv(table='user_groups', filename='groups.csv')
 ```
 
 Features
@@ -69,7 +69,7 @@ Features
 
 * Queries FOLIO modules and transforms JSON data into tables for
   easier reporting
-* Full SQL query support and export to CSV or Excel
+* Full SQL query support and export to CSV
 * Compatible with DBeaver database tool
 * Compatible with DuckDB and PostgreSQL database systems
 * PostgreSQL support enables:

--- a/examples/example.md
+++ b/examples/example.md
@@ -146,11 +146,9 @@ ld.select(table='user_groups', limit=10)
     (10 rows)
 
 ```python
-# The "user_groups" table can also be exported to a CSV or Excel file.
+# The "user_groups" table can also be exported to a CSV file.
 
 ld.export_csv(table='user_groups', filename='user_groups.csv')
-
-ld.export_excel(table='user_groups', filename='user_groups.xlsx')
 ```
 
 ```python

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -144,9 +144,9 @@ class LDLite:
         self,
         filename: str | None = None,
     ) -> sqlite3.Connection:
-        """Connects to an embedded SQLite database for storing data.
+        """Deprecated; this will be removed in the next major release of LDLite.
 
-        This method is experimental and may not be supported in future versions.
+        Connects to an embedded SQLite database for storing data.
 
         The optional *filename* designates a local file containing the SQLite
         database or where the database will be created if it does not exist.
@@ -550,7 +550,9 @@ class LDLite:
         table: str,
         header: bool = True,
     ) -> None:  # pragma: nocover
-        """Export a table in the reporting database to an Excel file.
+        """Deprecated; this will be removed in the next major release of LDLite.
+
+        Export a table in the reporting database to an Excel file.
 
         All rows of *table* are exported to *filename*, or *filename*.xlsx if
         *filename* does not have an extension.


### PR DESCRIPTION
For the transformation performance refactor I'm planning to use the native json functionality of duckdb and postgres. Sqlite has it but at a later version than what is built into python. It has to be removed to avoid maintaining two transformation code paths.

xlsx functionality is untested and it would be nice to drop it and the dependency. Excel can open csvs.