### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 ## [Unreleased]
 
 ### Added
-- New flag to remove the raw json tables after loading is complete
-
-### Added
 
 ### Fixed
 
@@ -27,6 +24,7 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 - Deprecation notice for xlsx and sqlite functionality. They will be removed in 4.0.
 - pdm scripts for locking and testing installability
 - New lockfile for testing python against 3.13
+- New flag to remove the raw json tables after loading is complete
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,28 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 
 ### Added
 
-- Deprecation notice for xlsx and sqlite functionality. They will be removed in 4.0.
+### Fixed
 
 ### Changed
 
-- Fixed endpoints that use with perPage instead of limit
-- Improved the performance and stability for the download portion of LDLite
-- Fixed `connect_db` method
-
 ### Removed
 
+## [3.1.0] - July 2025
+
+### Added
+
+- Deprecation notice for xlsx and sqlite functionality. They will be removed in 4.0.
+- pdm scripts for locking and testing installability
+- New lockfile for testing python against 3.13
+
+### Fixed
+
+- Fixed endpoints that use with perPage instead of limit
+- Fixed `connect_db` method
+
+### Changed
+
+- Improved the performance and stability for the download portion of LDLite
 
 ## [3.0.0] - July 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 
 ### Removed
 
-## [3.1.0] - July 2025
+## [3.1.0] - August 2025
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 ### Fixed
 
 - Fixed endpoints that use with perPage instead of limit
-- Fixed `connect_db` method
+- Fixed `connect_db` method return value
+- Re-enabled indexing for postgres databases
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "pdm.backend"
 
 [project]
 name = "ldlite"
-version = "3.0.0"
+version = "3.1.0"
 description = "Lightweight analytics tool for FOLIO services"
 authors = [
     {name = "Katherine Bargar", email = "kbargar@fivecolleges.edu"},

--- a/src/ldlite/folio.py
+++ b/src/ldlite/folio.py
@@ -68,7 +68,7 @@ class _RefreshTokenAuth(httpx.Auth):
 
 class _QueryParams:
     _default_re = re.compile(
-        r"^cql\.allrecords(?:=1)?(?:\s+sortby\s+id(?:\s+(asc|desc))?)?$",
+        r"^cql\.allrecords(?:=1)?(?:\s+sortby\s+id(?:(?:\/|\s)+(?:sort\.)?(asc|desc))?)?$",
         re.IGNORECASE,
     )
     _without_sort_re = re.compile(

--- a/src/ldlite/folio.py
+++ b/src/ldlite/folio.py
@@ -218,7 +218,7 @@ class FolioClient:
                 j = orjson.loads(res.text)[key]
                 yield from [(next(pkey), orjson.dumps(r)) for r in j]
 
-                if len(j) < page_size:
+                if len(j) == 0:
                     return
 
                 last_id = j[-1]["id"]

--- a/src/ldlite/folio.py
+++ b/src/ldlite/folio.py
@@ -139,7 +139,7 @@ class _QueryParams:
                 **self.additional_params,
                 "sort": "id;asc",
                 "filters": iter_query,
-                "query": q + " sortBy id asc",
+                "query": q + " sortBy id",
                 "limit": self.page_size,
                 "perPage": self.page_size,
                 "stats": True,

--- a/src/ldlite/folio.py
+++ b/src/ldlite/folio.py
@@ -203,7 +203,15 @@ class FolioClient:
                     params=params.for_values(),
                 ) as res:
                     res.raise_for_status()
-                    yield from ((next(pkey), r) for r in res.iter_lines())
+                    record = ""
+                    for f in res.iter_lines():
+                        # FOLIO can return partial json fragments
+                        # if they contain "newline-ish" characters like U+2028
+                        record += f
+                        if f[-1] == "}":
+                            yield (next(pkey), record)
+                            record = ""
+                            continue
                     return
 
             key = next(iter(j.keys()))

--- a/tests/test_cases/folio_query_cases.py
+++ b/tests/test_cases/folio_query_cases.py
@@ -25,9 +25,13 @@ _default_queries = [
     "cql.allRecords=1 sortby id desc",
     "cql.allRecords=1 SORTBY id ASC",
     "cql.allRecords=1 SORTBY id DESC",
+    "cql.allRecords=1 sortBy id/sort.asc",
+    "cql.allRecords=1 sortBy id/sort.desc",
 ]
 _nondefault_queries = [
     "some_query sortBy some_column",
+    "some_query sortBy some_column/and_another",
+    "some_query sortBy some_column and_another",
     "some_query sortBy some_column asc",
     "some_query sortBy some_column desc",
     "some_query sortby some_column",
@@ -35,6 +39,9 @@ _nondefault_queries = [
     "some_query sortby some_column desc",
     "some_query SORTBY some_column ASC",
     "some_query SORTBY some_column DESC",
+    "some_query sortBy some_column/sort.asc",
+    "some_query sortBy some_column/sort.desc",
+    "some_query sortBy some_column/sort.ignoreCase",
 ]
 
 

--- a/tests/test_folio/test_integration.py
+++ b/tests/test_folio/test_integration.py
@@ -79,6 +79,29 @@ def test_erm(folio_params: tuple[bool, FolioParams]) -> None:
     assert total == read
 
 
+def test_notes(folio_params: tuple[bool, FolioParams]) -> None:
+    if folio_params[0]:
+        pytest.skip("Specify an environment with --folio-base-url to run")
+
+    from ldlite.folio import FolioClient as uut
+
+    res = uut(folio_params[1]).iterate_records(
+        "/notes",  # Notes parses cql weirdly
+        timeout=60.0,
+        retries=0,
+        page_size=1,
+    )
+    next(res)
+
+    read = 0
+    for _ in res:
+        read += 1
+        if read > 2:
+            break
+
+    assert read > 0
+
+
 def test_srs(folio_params: tuple[bool, FolioParams]) -> None:
     if folio_params[0]:
         pytest.skip("Specify an environment with --folio-base-url to run")

--- a/tests/test_folio/test_integration.py
+++ b/tests/test_folio/test_integration.py
@@ -58,7 +58,7 @@ def test_erm(folio_params: tuple[bool, FolioParams]) -> None:
         "/erm/org",
         timeout=60.0,
         retries=0,
-        page_size=5,
+        page_size=101,  # erm caps to 100 per page
     )
 
     (total, _) = next(res)

--- a/tests/test_folio/test_query.py
+++ b/tests/test_folio/test_query.py
@@ -65,7 +65,7 @@ def test_nonsrs(
         assert calls[0][k] == v
 
     assert calls[1]["limit"] == str(tc.page_size)
-    assert calls[1]["query"] == tc.expected_values_query + " sortBy id asc"
+    assert calls[1]["query"] == tc.expected_values_query + " sortBy id"
     # erm parameters
     assert calls[1]["perPage"] == str(tc.page_size)
     assert calls[1]["stats"]


### PR DESCRIPTION
Performance enhancements and some quality of life changes. I've been running this version (installed from git) on the Five Colleges instances and fixing regressions uncovered while running in production as well.
* The /notes endpoint didn't recognize the "asc" portion of sortBy id asc.
* The ERM endpoint has a max page size of 100 and with the old loop condition we were only grabbing the first 100.
* The source record stream endpoint had issues when records contained "not quite newline" characters
* There was one more default query syntax variation to ignore