### PR TITLE
Rework the streaming srs endpoint to stream all records

### DIFF
--- a/tests/test_folio.py
+++ b/tests/test_folio.py
@@ -106,7 +106,7 @@ def test_src(folio_params: tuple[bool, FolioParams]) -> None:
         prev = record_id
 
         read += 1
-        if read >= 60:
+        if read >= 1000:
             break
 
     assert read > 0


### PR DESCRIPTION
After chatting with @duspal and reviewing his code samples in the FOLIO slack I have a much better idea of how the streaming endpoint works. This now properly utilizes streaming for SRS. I had a lot of trouble getting it to behave but then realized I unnecessarily was requesting the whole body in the custom auth class after copy + pasting from the httpx docs without knowing fully what I was doing : /

Co-authored-by: duspal <david.uspal@villanova.edu>