### PR TITLE
Re-enable indexing for postgres databases

### DIFF
--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -433,7 +433,7 @@ class LDLite:
                 for t, attrs in newattrs.items()
                 for n, a in attrs.items()
                 if n in ["__id", "id"]
-                or n.endswith(("Id", "__o"))
+                or n.endswith(("_id", "__o"))
                 or a.datatype == "uuid"
             ]
             index_total = len(indexable_attrs)

--- a/tests/test_cases/base.py
+++ b/tests/test_cases/base.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class TestCase:
+class EndToEndTestCase:
     values: dict[str, list[dict[str, Any]]]
 
     @cached_property

--- a/tests/test_cases/drop_tables_cases.py
+++ b/tests/test_cases/drop_tables_cases.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 
-from .base import TestCase
+from .base import EndToEndTestCase
 
 
 @dataclass(frozen=True)
-class DropTablesCase(TestCase):
+class DropTablesCase(EndToEndTestCase):
     drop: str
     expected_tables: list[str]
 

--- a/tests/test_cases/query_cases.py
+++ b/tests/test_cases/query_cases.py
@@ -4,11 +4,11 @@ from typing import Any
 
 from pytest_cases import parametrize
 
-from .base import TestCase
+from .base import EndToEndTestCase
 
 
 @dataclass(frozen=True)
-class QueryCase(TestCase):
+class QueryCase(EndToEndTestCase):
     json_depth: int
     expected_tables: list[str]
     expected_values: dict[str, tuple[list[str], list[tuple[Any, ...]]]]

--- a/tests/test_cases/query_cases.py
+++ b/tests/test_cases/query_cases.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from dataclasses import dataclass
 from typing import Any
@@ -12,6 +14,7 @@ class QueryCase(EndToEndTestCase):
     json_depth: int
     expected_tables: list[str]
     expected_values: dict[str, tuple[list[str], list[tuple[Any, ...]]]]
+    expected_indexes: list[tuple[str, str]] | None = None
 
 
 class QueryTestCases:
@@ -39,6 +42,11 @@ class QueryTestCases:
                 ),
                 "prefix__tcatalog": (["table_name"], [("prefix__t",)]),
             },
+            expected_indexes=[
+                ("prefix", "__id"),
+                ("prefix__t", "__id"),
+                ("prefix__t", "id"),
+            ],
         )
 
     @parametrize(json_depth=range(2, 3))
@@ -98,6 +106,15 @@ class QueryTestCases:
                     [("prefix__t",), ("prefix__t__sub_objects",)],
                 ),
             },
+            expected_indexes=[
+                ("prefix", "__id"),
+                ("prefix__t", "__id"),
+                ("prefix__t", "id"),
+                ("prefix__t__sub_objects", "__id"),
+                ("prefix__t__sub_objects", "id"),
+                ("prefix__t__sub_objects", "sub_objects__o"),
+                ("prefix__t__sub_objects", "sub_objects__id"),
+            ],
         )
 
     @parametrize(json_depth=range(1))
@@ -243,6 +260,27 @@ class QueryTestCases:
                     ],
                 ),
             },
+            expected_indexes=[
+                ("prefix", "__id"),
+                ("prefix__t", "__id"),
+                ("prefix__t", "id"),
+                ("prefix__t__sub_objects", "__id"),
+                ("prefix__t__sub_objects", "id"),
+                ("prefix__t__sub_objects", "sub_objects__o"),
+                ("prefix__t__sub_objects", "sub_objects__id"),
+                ("prefix__t__sub_objects__sub_sub_objects", "__id"),
+                ("prefix__t__sub_objects__sub_sub_objects", "id"),
+                ("prefix__t__sub_objects__sub_sub_objects", "sub_objects__o"),
+                ("prefix__t__sub_objects__sub_sub_objects", "sub_objects__id"),
+                (
+                    "prefix__t__sub_objects__sub_sub_objects",
+                    "sub_objects__sub_sub_objects__o",
+                ),
+                (
+                    "prefix__t__sub_objects__sub_sub_objects",
+                    "sub_objects__sub_sub_objects__id",
+                ),
+            ],
         )
 
     def case_nested_object(self) -> QueryCase:
@@ -282,6 +320,12 @@ class QueryTestCases:
                     [("prefix__t",)],
                 ),
             },
+            expected_indexes=[
+                ("prefix", "__id"),
+                ("prefix__t", "__id"),
+                ("prefix__t", "id"),
+                ("prefix__t", "sub_object__id"),
+            ],
         )
 
     def case_doubly_nested_object(self) -> QueryCase:
@@ -332,6 +376,13 @@ class QueryTestCases:
                     [("prefix__t",)],
                 ),
             },
+            expected_indexes=[
+                ("prefix", "__id"),
+                ("prefix__t", "__id"),
+                ("prefix__t", "id"),
+                ("prefix__t", "sub_object__id"),
+                ("prefix__t", "sub_object__sub_sub_object__id"),
+            ],
         )
 
     def case_nested_object_underexpansion(self) -> QueryCase:

--- a/tests/test_cases/query_cases.py
+++ b/tests/test_cases/query_cases.py
@@ -511,3 +511,36 @@ class QueryTestCases:
                 ),
             },
         )
+
+    def case_indexing_id_like(self) -> QueryCase:
+        return QueryCase(
+            json_depth=4,
+            values={
+                "prefix": [
+                    {
+                        "purchaseOrders": [
+                            {
+                                "id": "b096504a-3d54-4664-9bf5-1b872466fd66",
+                                "otherId": "b096504a-3d54-4664-9bf5-1b872466fd66",
+                                "anIdButWithADifferentEnding": (
+                                    "b096504a-3d54-4664-9bf5-1b872466fd66"
+                                ),
+                            },
+                        ],
+                    },
+                ],
+            },
+            expected_tables=[
+                "prefix",
+                "prefix__t",
+                "prefix__tcatalog",
+            ],
+            expected_values={},
+            expected_indexes=[
+                ("prefix", "__id"),
+                ("prefix__t", "__id"),
+                ("prefix__t", "id"),
+                ("prefix__t", "other_id"),
+                ("prefix__t", "an_id_but_with_a_different_ending"),
+            ],
+        )

--- a/tests/test_cases/to_csv_cases.py
+++ b/tests/test_cases/to_csv_cases.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-from .base import TestCase
+from .base import EndToEndTestCase
 
 _SAMPLE_PATH = Path() / "tests" / "test_cases" / "to_csv_samples"
 
 
 @dataclass(frozen=True)
-class ToCsvCase(TestCase):
+class ToCsvCase(EndToEndTestCase):
     expected_csvs: list[tuple[str, Path]]
 
 


### PR DESCRIPTION
When sqlite support was added the indexing on postgres was accidentally removed. When I discovered this bug it didn't seem like anyone was in a hurry to have it fixed so I wanted to rethink it before adding the behavior back in. For this PR, we're only indexing "id" and "id like" columns which are
* Columns literally __id and id
* Columns that act as indices for lists ending in __o
* Columns that end in "_id" which are probably foreign keys 
* UUID columns which are probably foreign keys

While this isn't perfect (or final) I think it strikes a good balance between re-enabling the existing behavior that indexed all columns (which took up a bunch of disk space unnecessarily) and have the indexes completely gone (which has worse performance).

This will close #16 when released.