### PR TITLE
Add a new parameter to drop the raw table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 ## [Unreleased]
 
 ### Added
+- New flag to remove the raw json tables after loading is complete
+
+### Added
 
 - Deprecation notice for xlsx and sqlite functionality. They will be removed in 4.0.
 

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -261,6 +261,7 @@ class LDLite:
         json_depth: int = 3,
         limit: int | None = None,
         transform: bool | None = None,
+        keep_raw: bool = True,
     ) -> list[str]:
         """Submits a query to a FOLIO module, and transforms and stores the result.
 
@@ -289,6 +290,9 @@ class LDLite:
 
         If *limit* is specified, then only up to *limit* records are
         retrieved.
+
+        If *keep_raw* is set to False, then the raw table of
+        __id, json will be dropped saving an estimated 20% disk space.
 
         The *transform* parameter is no longer supported and will be
         removed in the future.  Instead, specify *json_depth* as 0 to
@@ -424,6 +428,15 @@ class LDLite:
                 for t in newattrs:
                     newattrs[t]["__id"] = Attr("__id", "bigint")
                 newattrs[table] = {"__id": Attr("__id", "bigint")}
+
+            if not keep_raw:
+                cur = self.db.cursor()
+                try:
+                    cur.execute("DROP TABLE " + sqlid(table))
+                    self.db.commit()
+                finally:
+                    cur.close()
+
         finally:
             autocommit(self.db, self.dbtype, True)
         # Create indexes on id columns (for postgres)

--- a/tests/test_cases/drop_tables_cases.py
+++ b/tests/test_cases/drop_tables_cases.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+from pytest_cases import parametrize
+
 from .base import EndToEndTestCase
 
 
@@ -7,17 +9,21 @@ from .base import EndToEndTestCase
 class DropTablesCase(EndToEndTestCase):
     drop: str
     expected_tables: list[str]
+    keep_raw: bool
 
 
 class DropTablesCases:
-    def case_one_table(self) -> DropTablesCase:
+    @parametrize(keep_raw=[True, False])
+    def case_one_table(self, keep_raw: bool) -> DropTablesCase:
         return DropTablesCase(
             drop="prefix",
             values={"prefix": [{"purchaseOrders": [{"id": "1"}]}]},
             expected_tables=[],
+            keep_raw=keep_raw,
         )
 
-    def case_two_tables(self) -> DropTablesCase:
+    @parametrize(keep_raw=[True, False])
+    def case_two_tables(self, keep_raw: bool) -> DropTablesCase:
         return DropTablesCase(
             drop="prefix",
             values={
@@ -33,18 +39,24 @@ class DropTablesCases:
                 ],
             },
             expected_tables=[],
+            keep_raw=keep_raw,
         )
 
-    def case_separate_table(self) -> DropTablesCase:
+    @parametrize(keep_raw=[True, False])
+    def case_separate_table(self, keep_raw: bool) -> DropTablesCase:
+        expected_tables = [
+            "notdropped__t",
+            "notdropped__tcatalog",
+        ]
+        if keep_raw:
+            expected_tables = ["notdropped", *expected_tables]
+
         return DropTablesCase(
             drop="prefix",
             values={
                 "prefix": [{"purchaseOrders": [{"id": "1"}]}],
                 "notdropped": [{"purchaseOrders": [{"id": "1"}]}],
             },
-            expected_tables=[
-                "notdropped",
-                "notdropped__t",
-                "notdropped__tcatalog",
-            ],
+            expected_tables=expected_tables,
+            keep_raw=keep_raw,
         )

--- a/tests/test_cases/query_cases.py
+++ b/tests/test_cases/query_cases.py
@@ -15,6 +15,7 @@ class QueryCase(EndToEndTestCase):
     expected_tables: list[str]
     expected_values: dict[str, tuple[list[str], list[tuple[Any, ...]]]]
     expected_indexes: list[tuple[str, str]] | None = None
+    keep_raw: bool = True
 
 
 class QueryTestCases:
@@ -543,4 +544,35 @@ class QueryTestCases:
                 ("prefix__t", "other_id"),
                 ("prefix__t", "an_id_but_with_a_different_ending"),
             ],
+        )
+
+    @parametrize(json_depth=range(1, 2))
+    def case_drop_raw(self, json_depth: int) -> QueryCase:
+        return QueryCase(
+            json_depth=json_depth,
+            values={
+                "prefix": [
+                    {
+                        "purchaseOrders": [
+                            {
+                                "id": "b096504a-3d54-4664-9bf5-1b872466fd66",
+                                "value": "value",
+                            },
+                        ],
+                    },
+                ],
+            },
+            expected_tables=["prefix__t", "prefix__tcatalog"],
+            expected_values={
+                "prefix__t": (
+                    ["id", "value"],
+                    [("b096504a-3d54-4664-9bf5-1b872466fd66", "value")],
+                ),
+                "prefix__tcatalog": (["table_name"], [("prefix__t",)]),
+            },
+            expected_indexes=[
+                ("prefix__t", "__id"),
+                ("prefix__t", "id"),
+            ],
+            keep_raw=False,
         )

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -29,7 +29,7 @@ def test_drop_tables(
     ld.connect_db(dsn)
 
     for prefix in tc.values:
-        ld.query(table=prefix, path="/patched")
+        ld.query(table=prefix, path="/patched", keep_raw=tc.keep_raw)
     ld.drop_tables(tc.drop)
 
     with duckdb.connect(dsn) as res:
@@ -54,7 +54,12 @@ def test_query(
     ld.connect_db(dsn)
 
     for prefix in tc.values:
-        ld.query(table=prefix, path="/patched", json_depth=tc.json_depth)
+        ld.query(
+            table=prefix,
+            path="/patched",
+            json_depth=tc.json_depth,
+            keep_raw=tc.keep_raw,
+        )
 
     with duckdb.connect(dsn) as res:
         res.execute("SHOW TABLES;")

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -58,7 +58,7 @@ def test_drop_tables(
     ld.connect_db_postgresql(dsn)
 
     for prefix in tc.values:
-        ld.query(table=prefix, path="/patched")
+        ld.query(table=prefix, path="/patched", keep_raw=tc.keep_raw)
     ld.drop_tables(tc.drop)
 
     with psycopg2.connect(dsn) as conn, conn.cursor() as res:
@@ -93,7 +93,12 @@ def test_query(
     ld.connect_db_postgresql(dsn)
 
     for prefix in tc.values:
-        ld.query(table=prefix, path="/patched", json_depth=tc.json_depth)
+        ld.query(
+            table=prefix,
+            path="/patched",
+            json_depth=tc.json_depth,
+            keep_raw=tc.keep_raw,
+        )
 
     with psycopg2.connect(dsn) as conn:
         with conn.cursor() as res:

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -30,7 +30,7 @@ def test_drop_tables(
     ld.experimental_connect_db_sqlite(dsn)
 
     for prefix in tc.values:
-        ld.query(table=prefix, path="/patched")
+        ld.query(table=prefix, path="/patched", keep_raw=tc.keep_raw)
     ld.drop_tables(tc.drop)
 
     with sqlite3.connect(dsn) as conn, contextlib.closing(conn.cursor()) as res:
@@ -55,7 +55,12 @@ def test_query(
     ld.experimental_connect_db_sqlite(dsn)
 
     for prefix in tc.values:
-        ld.query(table=prefix, path="/patched", json_depth=tc.json_depth)
+        ld.query(
+            table=prefix,
+            path="/patched",
+            json_depth=tc.json_depth,
+            keep_raw=tc.keep_raw,
+        )
 
     with sqlite3.connect(dsn) as conn:
         with contextlib.closing(conn.cursor()) as res:


### PR DESCRIPTION
After transformation the table with the raw json is redundant and can be deleted to save disk space. This adds a backwards compatible parameter to the query method to allow for dropping the raw table. I've estimated this to save ~20% of disk space. In combination with the indexing change in #31 we're looking at a potential postgres disk saving of ~30% or $250 a year in the 5 Colleges instance.