### PR TITLE
Re-implement dictionary queries and add more robust default query handling

### DIFF
--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -257,7 +257,7 @@ class LDLite:
         self,
         table: str,
         path: str,
-        query: str | None = None,
+        query: str | dict[str, str] | None = None,
         json_depth: int = 3,
         limit: int | None = None,
         transform: bool | None = None,
@@ -311,9 +311,6 @@ class LDLite:
                 "use json_depth=0 to disable JSON transformation"
             )
             raise ValueError(msg)
-        if query == "cql.allRecords=1 sortby id":
-            # this is everywhere in the docs but isn't necessary with the new client
-            query = None
         schema_table = table.split(".")
         if len(schema_table) != 1 and len(schema_table) != 2:
             raise ValueError("invalid table name: " + table)

--- a/src/ldlite/folio.py
+++ b/src/ldlite/folio.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from itertools import count
 from typing import TYPE_CHECKING
@@ -65,6 +66,79 @@ class _RefreshTokenAuth(httpx.Auth):
         return hdr
 
 
+class _QueryParams:
+    _default_re = re.compile(
+        r"^cql\.allrecords(?:=1)?(?:\s+sortby\s+id(?:\s+(asc|desc))?)?$",
+        re.IGNORECASE,
+    )
+    _without_sort_re = re.compile(
+        r"^(.*?)(?:\s+sortby.*)?$",
+        re.IGNORECASE,
+    )
+
+    def __init__(
+        self,
+        query: str | dict[str, str] | None,
+        page_size: int,
+    ):
+        if (
+            query is None
+            or isinstance(query, dict)
+            or self._default_re.match(query) is not None
+        ):
+            # See below for papering over sort desc notes
+            self.query_str = None
+        else:
+            self.query_str = query
+
+        if (
+            self.query_str is not None
+            and (without_sort := self._without_sort_re.match(self.query_str))
+            is not None
+            and len(without_sort.groups()) > 0
+        ):
+            # We're dumping any sort the user did supply
+            # This might get weird if the user is relying on
+            # both a desc query and a limit on the result set
+            # I'm gambling that this isn't happening
+            self.query_str = without_sort.groups()[0]
+
+        self.page_size = str(page_size)
+
+    def for_stats(self) -> httpx.QueryParams:
+        q = self.query_str if self.query_str is not None else "cql.allRecords=1"
+        return httpx.QueryParams(
+            {
+                "query": q,
+                "limit": 1,
+                # ERM endpoints use perPage and stats
+                # Additional filtering for ERM endpoints is ignored
+                # (for now because stats doesn't actually impact behavior)
+                "perPage": 1,
+                "stats": True,
+            },
+        )
+
+    def for_values(self, last_id: str | None) -> httpx.QueryParams:
+        if last_id is None:
+            last_id = "00000000-0000-0000-0000-000000000000"
+        iter_query = f"id>{last_id}"
+        q = iter_query + (
+            f" and ({self.query_str})" if self.query_str is not None else ""
+        )
+        # Additional filtering beyond ids for ERM endpoints is ignored
+        return httpx.QueryParams(
+            {
+                "sort": "id;asc",
+                "filters": iter_query,
+                "query": q + " sortBy id asc",
+                "limit": self.page_size,
+                "perPage": self.page_size,
+                "stats": True,
+            },
+        )
+
+
 class FolioClient:
     """Client for reliably and performantly fetching FOLIO records."""
 
@@ -87,9 +161,8 @@ class FolioClient:
             A tuple of the autoincrementing key + the json for each record.
             The first result will be the total record count.
         """
-        if isinstance(query, dict):
-            return
         is_src = path.startswith("/source-storage")
+        params = _QueryParams(query, page_size)
 
         with httpx.Client(
             base_url=self._base_url,
@@ -97,21 +170,11 @@ class FolioClient:
             transport=RetryTransport(retry=Retry(total=retries, backoff_factor=0.5)),
             timeout=timeout,
         ) as client:
-            q = query if query is not None else "cql.allRecords=1"
             res = client.get(
                 # Hardcode the source storage endpoint that returns stats
                 # even if the user passes in the stream endpoint
                 path if not is_src else "/source-storage/source-records",
-                # ERM endpoints use perPage and stats
-                # Additional filtering for ERM endpoints is ignored
-                params=httpx.QueryParams(
-                    {
-                        "query": q,
-                        "limit": 1,
-                        "perPage": 1,
-                        "stats": True,
-                    },
-                ),
+                params=params.for_stats(),
             )
             res.raise_for_status()
             j = orjson.loads(res.text)
@@ -136,24 +199,11 @@ class FolioClient:
                     return
 
             key = next(iter(j.keys()))
-            last_id = "00000000-0000-0000-0000-000000000000"
+            last_id: str | None = None
             while True:
-                iter_query = f"id>{last_id}"
-                # Additional filtering for ERM endpoints is ignored
-                q = query + " " + iter_query if query is not None else iter_query
-                p = httpx.QueryParams(
-                    {
-                        "sort": "id;asc",
-                        "filters": iter_query,
-                        "query": q + " sortBy id asc",
-                        "limit": page_size,
-                        "perPage": page_size,
-                        "stats": True,
-                    },
-                )
                 res = client.get(
                     path,
-                    params=p,
+                    params=params.for_values(last_id),
                 )
                 res.raise_for_status()
 

--- a/tests/test_cases/folio_query_cases.py
+++ b/tests/test_cases/folio_query_cases.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from pytest_cases import parametrize
 
@@ -12,6 +12,30 @@ class NonSRSQueryTestCase:
     expected_total_query: str = "cql.allRecords=1"
     expected_values_query: str = "id>00000000-0000-0000-0000-000000000000"
     expected_filters_query: str = "id>00000000-0000-0000-0000-000000000000"
+    expected_additional_params: dict[str, str] = field(default_factory=dict)
+
+
+_default_queries = [
+    "cql.allRecords=1",
+    "cql.allRecords=1 sortBy id",
+    "cql.allRecords=1 sortBy id asc",
+    "cql.allRecords=1 sortBy id desc",
+    "cql.allRecords=1 sortby id",
+    "cql.allRecords=1 sortby id asc",
+    "cql.allRecords=1 sortby id desc",
+    "cql.allRecords=1 SORTBY id ASC",
+    "cql.allRecords=1 SORTBY id DESC",
+]
+_nondefault_queries = [
+    "some_query sortBy some_column",
+    "some_query sortBy some_column asc",
+    "some_query sortBy some_column desc",
+    "some_query sortby some_column",
+    "some_query sortby some_column asc",
+    "some_query sortby some_column desc",
+    "some_query SORTBY some_column ASC",
+    "some_query SORTBY some_column DESC",
+]
 
 
 class NonSRSQueryTestCases:
@@ -30,34 +54,11 @@ class NonSRSQueryTestCases:
     def custom_page_size(self) -> NonSRSQueryTestCase:
         return NonSRSQueryTestCase(page_size=50)
 
-    @parametrize(
-        q=[
-            "cql.allRecords=1",
-            "cql.allRecords=1 sortBy id",
-            "cql.allRecords=1 sortBy id asc",
-            "cql.allRecords=1 sortBy id desc",
-            "cql.allRecords=1 sortby id",
-            "cql.allRecords=1 sortby id asc",
-            "cql.allRecords=1 sortby id desc",
-            "cql.allRecords=1 SORTBY id ASC",
-            "cql.allRecords=1 SORTBY id DESC",
-        ],
-    )
+    @parametrize(q=_default_queries)
     def case_default_query(self, q: str) -> NonSRSQueryTestCase:
         return NonSRSQueryTestCase(query=q)
 
-    @parametrize(
-        q=[
-            "some_query sortBy some_column",
-            "some_query sortBy some_column asc",
-            "some_query sortBy some_column desc",
-            "some_query sortby some_column",
-            "some_query sortby some_column asc",
-            "some_query sortby some_column desc",
-            "some_query SORTBY some_column ASC",
-            "some_query SORTBY some_column DESC",
-        ],
-    )
+    @parametrize(q=_nondefault_queries)
     def case_sort_query(self, q: str) -> NonSRSQueryTestCase:
         return NonSRSQueryTestCase(
             query=q,
@@ -65,4 +66,42 @@ class NonSRSQueryTestCases:
             expected_values_query=(
                 "id>00000000-0000-0000-0000-000000000000 and (some_query)"
             ),
+        )
+
+    def case_nooverride_dict(self) -> NonSRSQueryTestCase:
+        return NonSRSQueryTestCase(
+            query={
+                "limit": "limit",
+                "perPage": "perPage",
+                "stats": "stats",
+                "sort": "sort",
+                "filters": "filters",
+            },
+        )
+
+    def case_additional_params(self) -> NonSRSQueryTestCase:
+        p = {"additional": "param1", "and": "param2"}
+        return NonSRSQueryTestCase(
+            query=p,
+            expected_additional_params=p,
+        )
+
+    @parametrize(q=_default_queries)
+    def case_default_query_dict(self, q: str) -> NonSRSQueryTestCase:
+        p = {"additional": "param1", "and": "param2"}
+        return NonSRSQueryTestCase(
+            query={"query": q, **p},
+            expected_additional_params=p,
+        )
+
+    @parametrize(q=_nondefault_queries)
+    def case_sort_query_dict(self, q: str) -> NonSRSQueryTestCase:
+        p = {"additional": "param1", "and": "param2"}
+        return NonSRSQueryTestCase(
+            query={"query": q, **p},
+            expected_total_query="some_query",
+            expected_values_query=(
+                "id>00000000-0000-0000-0000-000000000000 and (some_query)"
+            ),
+            expected_additional_params=p,
         )

--- a/tests/test_cases/folio_query_cases.py
+++ b/tests/test_cases/folio_query_cases.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pytest_cases import parametrize
+
 
 @dataclass(frozen=True)
 class NonSRSQueryTestCase:
@@ -9,11 +11,58 @@ class NonSRSQueryTestCase:
     page_size: int = 1000
     expected_total_query: str = "cql.allRecords=1"
     expected_values_query: str = "id>00000000-0000-0000-0000-000000000000"
+    expected_filters_query: str = "id>00000000-0000-0000-0000-000000000000"
 
 
 class NonSRSQueryTestCases:
     def case_no_query(self) -> NonSRSQueryTestCase:
         return NonSRSQueryTestCase()
 
+    def case_with_query(self) -> NonSRSQueryTestCase:
+        return NonSRSQueryTestCase(
+            query="some_query",
+            expected_total_query="some_query",
+            expected_values_query=(
+                "id>00000000-0000-0000-0000-000000000000 and (some_query)"
+            ),
+        )
+
     def custom_page_size(self) -> NonSRSQueryTestCase:
         return NonSRSQueryTestCase(page_size=50)
+
+    @parametrize(
+        q=[
+            "cql.allRecords=1",
+            "cql.allRecords=1 sortBy id",
+            "cql.allRecords=1 sortBy id asc",
+            "cql.allRecords=1 sortBy id desc",
+            "cql.allRecords=1 sortby id",
+            "cql.allRecords=1 sortby id asc",
+            "cql.allRecords=1 sortby id desc",
+            "cql.allRecords=1 SORTBY id ASC",
+            "cql.allRecords=1 SORTBY id DESC",
+        ],
+    )
+    def case_default_query(self, q: str) -> NonSRSQueryTestCase:
+        return NonSRSQueryTestCase(query=q)
+
+    @parametrize(
+        q=[
+            "some_query sortBy some_column",
+            "some_query sortBy some_column asc",
+            "some_query sortBy some_column desc",
+            "some_query sortby some_column",
+            "some_query sortby some_column asc",
+            "some_query sortby some_column desc",
+            "some_query SORTBY some_column ASC",
+            "some_query SORTBY some_column DESC",
+        ],
+    )
+    def case_sort_query(self, q: str) -> NonSRSQueryTestCase:
+        return NonSRSQueryTestCase(
+            query=q,
+            expected_total_query="some_query",
+            expected_values_query=(
+                "id>00000000-0000-0000-0000-000000000000 and (some_query)"
+            ),
+        )

--- a/tests/test_cases/folio_query_cases.py
+++ b/tests/test_cases/folio_query_cases.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NonSRSQueryTestCase:
+    query: str | dict[str, str] | None = None
+    page_size: int = 1000
+    expected_total_query: str = "cql.allRecords=1"
+    expected_values_query: str = "id>00000000-0000-0000-0000-000000000000"
+
+
+class NonSRSQueryTestCases:
+    def case_no_query(self) -> NonSRSQueryTestCase:
+        return NonSRSQueryTestCase()
+
+    def custom_page_size(self) -> NonSRSQueryTestCase:
+        return NonSRSQueryTestCase(page_size=50)

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -7,9 +7,9 @@ import duckdb
 import pytest
 from pytest_cases import parametrize_with_cases
 
-from .test_cases import drop_tables_cases as dtc
-from .test_cases import query_cases as qc
-from .test_cases import to_csv_cases as csvc
+from tests.test_cases import drop_tables_cases as dtc
+from tests.test_cases import query_cases as qc
+from tests.test_cases import to_csv_cases as csvc
 
 
 @mock.patch("ldlite.folio.httpx.post")

--- a/tests/test_folio/test_integration.py
+++ b/tests/test_folio/test_integration.py
@@ -79,7 +79,7 @@ def test_erm(folio_params: tuple[bool, FolioParams]) -> None:
     assert total == read
 
 
-def test_src(folio_params: tuple[bool, FolioParams]) -> None:
+def test_srs(folio_params: tuple[bool, FolioParams]) -> None:
     if folio_params[0]:
         pytest.skip("Specify an environment with --folio-base-url to run")
 

--- a/tests/test_folio/test_integration.py
+++ b/tests/test_folio/test_integration.py
@@ -1,6 +1,4 @@
 import json
-from unittest import mock
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -108,42 +106,3 @@ def test_src(folio_params: tuple[bool, FolioParams]) -> None:
             break
 
     assert read > 0
-
-
-@mock.patch("ldlite.folio.httpx.post")
-@mock.patch("ldlite.folio.httpx.Client.get")
-def test_query_parameter(
-    client_get_mock: MagicMock,
-    httpx_post_mock: MagicMock,
-) -> None:
-    from ldlite.folio import FolioClient as uut
-
-    httpx_post_mock.return_value.cookies.__getitem__.return_value = "token"
-
-    total_mock = MagicMock()
-    total_mock.text = '{"key": "", "totalRecords": 100000}'
-
-    values_mock = MagicMock()
-    values_mock.text = '{"key": [], "totalRecords": 100000}'
-
-    calls = 0
-
-    def check_calls() -> MagicMock:
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            return total_mock
-        return values_mock
-
-    client_get_mock.side_effect = check_calls
-
-    list(
-        uut(FolioParams("", "", "", "")).iterate_records(
-            "/literally/anything",
-            timeout=60.0,
-            retries=0,
-            page_size=5,
-        )
-    )
-
-    assert calls == 2

--- a/tests/test_folio/test_query.py
+++ b/tests/test_folio/test_query.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import typing
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_cases import parametrize_with_cases
+
+from ldlite.folio import FolioParams
+from tests.test_cases import folio_query_cases as fqc
+
+if typing.TYPE_CHECKING:
+    import httpx
+
+
+@mock.patch("ldlite.folio.httpx.post")
+@mock.patch("ldlite.folio.httpx.Client.get")
+@parametrize_with_cases("tc", cases=fqc.NonSRSQueryTestCases)
+def test_nonsrs(
+    client_get_mock: MagicMock,
+    httpx_post_mock: MagicMock,
+    tc: fqc.NonSRSQueryTestCase,
+) -> None:
+    from ldlite.folio import FolioClient as uut
+
+    httpx_post_mock.return_value.cookies.__getitem__.return_value = "token"
+
+    total_mock = MagicMock()
+    total_mock.text = '{"key": "", "totalRecords": 100000}'
+
+    values_mock = MagicMock()
+    values_mock.text = '{"key": [], "totalRecords": 100000}'
+
+    calls = 0
+
+    def check_calls(*_: str, **kwargs: dict[str, typing.Any]) -> MagicMock:
+        assert "params" in kwargs
+        q = typing.cast("httpx.QueryParams", kwargs["params"])
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            assert q["limit"] == "1"
+            assert q["query"] == tc.expected_total_query
+            # erm parameters
+            assert q["perPage"] == "1"
+            assert q["stats"]
+            return total_mock
+
+        if calls == 2:
+            assert q["limit"] == str(tc.page_size)
+            assert q["query"] == tc.expected_values_query + " sortBy id asc"
+            # erm parameters
+            assert q["perPage"] == str(tc.page_size)
+            assert q["stats"]
+            assert q["sort"] == "id;asc"
+            assert q["filters"] == tc.expected_values_query
+            return values_mock
+
+        pytest.fail("Requested multiple pages of values")
+
+    client_get_mock.side_effect = check_calls
+
+    list(
+        uut(FolioParams("", "", "", "")).iterate_records(
+            "/literally/anything",
+            timeout=60.0,
+            retries=0,
+            page_size=tc.page_size,
+            query=tc.query,
+        ),
+    )
+
+    assert calls == 2

--- a/tests/test_folio/test_query.py
+++ b/tests/test_folio/test_query.py
@@ -4,7 +4,6 @@ import typing
 from unittest import mock
 from unittest.mock import MagicMock
 
-import pytest
 from pytest_cases import parametrize_with_cases
 
 from ldlite.folio import FolioParams
@@ -26,38 +25,21 @@ def test_nonsrs(
 
     httpx_post_mock.return_value.cookies.__getitem__.return_value = "token"
 
+    mocks = []
     total_mock = MagicMock()
     total_mock.text = '{"key": "", "totalRecords": 100000}'
+    mocks.append(total_mock)
 
     values_mock = MagicMock()
     values_mock.text = '{"key": [], "totalRecords": 100000}'
+    mocks.append(values_mock)
 
-    calls = 0
+    calls: list[httpx.QueryParams] = []
 
     def check_calls(*_: str, **kwargs: dict[str, typing.Any]) -> MagicMock:
         assert "params" in kwargs
-        q = typing.cast("httpx.QueryParams", kwargs["params"])
-        nonlocal calls
-        calls += 1
-        if calls == 1:
-            assert q["limit"] == "1"
-            assert q["query"] == tc.expected_total_query
-            # erm parameters
-            assert q["perPage"] == "1"
-            assert q["stats"]
-            return total_mock
-
-        if calls == 2:
-            assert q["limit"] == str(tc.page_size)
-            assert q["query"] == tc.expected_values_query + " sortBy id asc"
-            # erm parameters
-            assert q["perPage"] == str(tc.page_size)
-            assert q["stats"]
-            assert q["sort"] == "id;asc"
-            assert q["filters"] == tc.expected_values_query
-            return values_mock
-
-        pytest.fail("Requested multiple pages of values")
+        calls.append(typing.cast("httpx.QueryParams", kwargs["params"]))
+        return mocks.pop(-1)
 
     client_get_mock.side_effect = check_calls
 
@@ -71,4 +53,18 @@ def test_nonsrs(
         ),
     )
 
-    assert calls == 2
+    assert len(calls) == 2
+
+    assert calls[0]["limit"] == "1"
+    assert calls[0]["query"] == tc.expected_total_query
+    # erm parameters
+    assert calls[0]["perPage"] == "1"
+    assert calls[0]["stats"]
+
+    assert calls[1]["limit"] == str(tc.page_size)
+    assert calls[1]["query"] == tc.expected_values_query + " sortBy id asc"
+    # erm parameters
+    assert calls[1]["perPage"] == str(tc.page_size)
+    assert calls[1]["stats"]
+    assert calls[1]["sort"] == "id;asc"
+    assert calls[1]["filters"] == tc.expected_filters_query

--- a/tests/test_folio/test_query.py
+++ b/tests/test_folio/test_query.py
@@ -60,6 +60,9 @@ def test_nonsrs(
     # erm parameters
     assert calls[0]["perPage"] == "1"
     assert calls[0]["stats"]
+    for k, v in tc.expected_additional_params.items():
+        assert k in calls[0]
+        assert calls[0][k] == v
 
     assert calls[1]["limit"] == str(tc.page_size)
     assert calls[1]["query"] == tc.expected_values_query + " sortBy id asc"
@@ -68,3 +71,6 @@ def test_nonsrs(
     assert calls[1]["stats"]
     assert calls[1]["sort"] == "id;asc"
     assert calls[1]["filters"] == tc.expected_filters_query
+    for k, v in tc.expected_additional_params.items():
+        assert k in calls[1]
+        assert calls[1][k] == v

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -11,9 +11,9 @@ import psycopg2
 import pytest
 from pytest_cases import parametrize_with_cases
 
-from .test_cases import drop_tables_cases as dtc
-from .test_cases import query_cases as qc
-from .test_cases import to_csv_cases as csvc
+from tests.test_cases import drop_tables_cases as dtc
+from tests.test_cases import query_cases as qc
+from tests.test_cases import to_csv_cases as csvc
 
 if TYPE_CHECKING:
     from unittest.mock import MagicMock

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -8,9 +8,9 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_cases import parametrize_with_cases
 
-from .test_cases import drop_tables_cases as dtc
-from .test_cases import query_cases as qc
-from .test_cases import to_csv_cases as csvc
+from tests.test_cases import drop_tables_cases as dtc
+from tests.test_cases import query_cases as qc
+from tests.test_cases import to_csv_cases as csvc
 
 
 @mock.patch("ldlite.folio.httpx.post")


### PR DESCRIPTION
While working on the fix to the source record endpoint I realized I dropped the ability to pass dictionaries as queries at some point. The original behavior was really only documented in the srs.md file. I've re-added the functionality as well as types and tests.

Previously, `cql.allRecords sortBy id asc` or some variation of this query was everywhere in the docs. This query can still be passed but it won't have an effect as we've switched to id based paging from offset based paging. I had done this less robustly before but wanted to flesh it out more with tests and everything.