### PR TITLE
Switch from INSERT INTO to COPY FROM for postgres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Please see [MIGRATING.md](./MIGRATING.md) for information on breaking changes.
 - psycopg3 is now used for internal operations. LDLite.connect_db_postgres will return a psycopg3 connection instead of psycopg2 in the next major release.
 - psycopg2 is now installed using the binary version.
 - Refactored internal database handling logic
+- Ingesting data into postgres now uses COPY FROM which significantly improves the download performance.
 
 ### Removed
 

--- a/src/ldlite/__init__.py
+++ b/src/ldlite/__init__.py
@@ -62,6 +62,8 @@ from ._sqlx import (
 from ._xlsx import to_xlsx
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from _typeshed import dbapi
     from httpx_folio.query import QueryType
 
@@ -362,7 +364,7 @@ class LDLite:
                 self.page_size,
                 query=cast("QueryType", query),
             )
-            (total_records, _) = next(records)
+            total_records = cast("int", next(records))
             total = min(total_records, limit or total_records)
             if self._verbose:
                 print("ldlite: estimated row count: " + str(total), file=sys.stderr)
@@ -403,7 +405,7 @@ class LDLite:
             self._db.ingest_records(
                 prefix,
                 on_processed_limit if limit is not None else on_processed,
-                records,
+                cast("Iterator[tuple[bytes, bytes] | tuple[int, str]]", records),
             )
             pbar.close()
 

--- a/src/ldlite/_database.py
+++ b/src/ldlite/_database.py
@@ -173,21 +173,31 @@ class Database(ABC, Generic[DB]):
         self,
         prefix: Prefix,
         on_processed: Callable[[], bool],
-        records: Iterator[tuple[int, str | bytes]],
+        records: Iterator[tuple[bytes, bytes] | tuple[int, str]],
     ) -> None:
         with closing(self._conn_factory()) as conn:
             self._prepare_raw_table(conn, prefix)
+            insert_sql = self._insert_record_sql.format(
+                table=prefix.raw_table_name,
+            ).as_string()
             with closing(conn.cursor()) as cur:
-                is_str = None
-                for pkey, r in records:
-                    if is_str is None:
-                        is_str = isinstance(r, str)
-                    cur.execute(
-                        self._insert_record_sql.format(
-                            table=prefix.raw_table_name,
-                        ).as_string(),
-                        [pkey, r if is_str else cast("bytes", r).decode()],
-                    )
-                    if not on_processed():
-                        break
+                fr = next(records)
+                if isinstance(fr[0], bytes):
+                    record = fr
+                    while record is not None:
+                        (pkey, rb) = record
+                        cur.execute(
+                            insert_sql,
+                            (int.from_bytes(pkey, "big"), rb.decode()),
+                        )
+                        if not on_processed():
+                            break
+                        record = cast("tuple[bytes, bytes]", next(records, None))
+                else:
+                    cur.execute(insert_sql, fr)
+                    for r in records:
+                        cur.execute(insert_sql, r)
+                        if not on_processed():
+                            break
+
             conn.commit()

--- a/src/ldlite/_folio.py
+++ b/src/ldlite/_folio.py
@@ -28,7 +28,7 @@ class FolioClient:
         retries: int,
         page_size: int,
         query: QueryType | None = None,
-    ) -> Iterator[tuple[int, str | bytes]]:
+    ) -> Iterator[int | tuple[bytes, bytes] | tuple[int, str]]:
         """Iterates all records for a given path.
 
         Returns:
@@ -54,7 +54,7 @@ class FolioClient:
             res.raise_for_status()
             j = orjson.loads(res.text)
             r = int(j["totalRecords"])
-            yield (r, b"")
+            yield r
 
             if r == 0:
                 return
@@ -103,7 +103,7 @@ class FolioClient:
                 last = None
                 for r in (o for o in orjson.loads(res.text)[key] if o is not None):
                     last = r
-                    yield (next(pkey), orjson.dumps(r))
+                    yield (next(pkey).to_bytes(4, "big"), orjson.dumps(r))
 
                 if last is None:
                     return

--- a/src/ldlite/_sqlx.py
+++ b/src/ldlite/_sqlx.py
@@ -105,10 +105,10 @@ class DBTypeDatabase(Database["dbapi.DBAPIConnection"]):
                         record = fr
                         while record is not None:
                             pkey, rb = record
-                            rpg = bytearray()
-                            rpg.extend(jver)
-                            rpg.extend(cast("bytes", rb))
-                            copy.write_row((pkey, rpg))
+                            rbpg = bytearray()
+                            rbpg.extend(jver)
+                            rbpg.extend(cast("bytes", rb))
+                            copy.write_row((pkey, rbpg))
                             if not on_processed():
                                 break
                             record = cast("tuple[bytes, bytes]", next(records, None))


### PR DESCRIPTION
Using COPY FROM is an order of magnitude faster for bulk insertions for postgres. This is the last low-hanging fruit for download performance until async/await is supported and optimized for in a future future release. DuckDB can kind of sort of do bulk operations but it isn't a priority right now, especially with sqlite still supported in this release.

Getting bytes do go directly into the database was a bit of a struggle but postgres expects a "version" byte at the beginning of any record. By doing the byte munging ourselves we skip a whole lot of conversion in ldlite and conversion/logic in psycopg which would have added points of failure and slowness. I'm going to be testing to make sure it works across 5C FOLIO data before releasing the change.