### PR TITLE
Abstract json processing differences between duckdb and postgres

### DIFF
--- a/src/ldlite/_database/duckdb.py
+++ b/src/ldlite/_database/duckdb.py
@@ -32,6 +32,7 @@ CREATE OR REPLACE FUNCTION ldlite_system.jextract(j, p) AS
         WHEN 'string' THEN
             CASE
                 WHEN lower(main.json_extract_string(j, p)) = 'null' THEN 'null'::JSON
+                WHEN length(main.json_extract_string(j, p)) = 0 THEN 'null'::JSON
                 ELSE main.json_extract(j, p)
             END
         WHEN 'object' THEN
@@ -55,6 +56,13 @@ CREATE OR REPLACE FUNCTION ldlite_system.jextract_string(j, p) AS
 CREATE OR REPLACE FUNCTION ldlite_system.jobject_keys(j) AS
     unnest(main.json_keys(j))
 ;
+CREATE OR REPLACE FUNCTION ldlite_system.jis_uuid(j) AS
+    CASE ldlite_system.jtype_of(j)
+        WHEN 'string' THEN regexp_full_match(main.json_extract_string(j, '$'), '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$')
+        ELSE FALSE
+    END
+;
+
 """,  # noqa: E501
             )
 

--- a/src/ldlite/_database/duckdb.py
+++ b/src/ldlite/_database/duckdb.py
@@ -32,7 +32,9 @@ CREATE OR REPLACE FUNCTION ldlite_system.jtype_of(j) AS
         WHEN 'DOUBLE' THEN 'number'
         WHEN 'UBIGINT' THEN 'number'
         WHEN 'OBJECT' THEN 'object'
+        WHEN 'BOOLEAN' THEN 'boolean'
         WHEN 'ARRAY' THEN 'array'
+        WHEN 'NULL' THEN 'null'
         ELSE main.json_type(j)
     END
 ;

--- a/src/ldlite/_database/duckdb.py
+++ b/src/ldlite/_database/duckdb.py
@@ -8,6 +8,20 @@ from . import Prefix, TypedDatabase
 
 
 class DuckDbDatabase(TypedDatabase[duckdb.DuckDBPyConnection]):
+    @staticmethod
+    def _setup_jfuncs(conn: duckdb.DuckDBPyConnection) -> None:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+CREATE OR REPLACE FUNCTION ldlite_system.jextract(j, p) AS
+    main.json_extract(j, p)
+;
+CREATE OR REPLACE FUNCTION ldlite_system.jextract_string(j, p) AS
+    main.json_extract_string(j, p)
+;
+""",
+            )
+
     @property
     def _default_schema(self) -> str:
         return "main"

--- a/src/ldlite/_database/duckdb.py
+++ b/src/ldlite/_database/duckdb.py
@@ -23,6 +23,19 @@ CREATE OR REPLACE FUNCTION ldlite_system.jextract_string(j, p) AS
 
 CREATE OR REPLACE FUNCTION ldlite_system.jobject_keys(j) AS
     unnest(main.json_keys(j))
+;
+
+CREATE OR REPLACE FUNCTION ldlite_system.jtype_of(j) AS
+    CASE main.json_type(j)
+        WHEN 'VARCHAR' THEN 'string'
+        WHEN 'BIGINT' THEN 'number'
+        WHEN 'DOUBLE' THEN 'number'
+        WHEN 'UBIGINT' THEN 'number'
+        WHEN 'OBJECT' THEN 'object'
+        WHEN 'ARRAY' THEN 'array'
+        ELSE main.json_type(j)
+    END
+;
 """,
             )
 

--- a/src/ldlite/_database/duckdb.py
+++ b/src/ldlite/_database/duckdb.py
@@ -38,6 +38,10 @@ CREATE OR REPLACE FUNCTION ldlite_system.jtype_of(j) AS
         ELSE main.json_type(j)
     END
 ;
+
+CREATE OR REPLACE FUNCTION ldlite_system.jarray_length(j) AS
+    main.json_array_length(j)
+;
 """,
             )
 

--- a/src/ldlite/_database/duckdb.py
+++ b/src/ldlite/_database/duckdb.py
@@ -20,6 +20,9 @@ CREATE OR REPLACE FUNCTION ldlite_system.jextract(j, p) AS
 CREATE OR REPLACE FUNCTION ldlite_system.jextract_string(j, p) AS
     main.json_extract_string(j, p)
 ;
+
+CREATE OR REPLACE FUNCTION ldlite_system.jobject_keys(j) AS
+    unnest(main.json_keys(j))
 """,
             )
 

--- a/src/ldlite/_database/duckdb.py
+++ b/src/ldlite/_database/duckdb.py
@@ -71,6 +71,13 @@ CREATE OR REPLACE FUNCTION ldlite_system.jis_datetime(j) AS
     END
 ;
 
+CREATE OR REPLACE FUNCTION ldlite_system.jis_float(j) AS
+    CASE ldlite_system.jtype_of(j)
+        WHEN 'number' THEN contains(main.json_extract_string(j, '$'), '.')
+        ELSE FALSE
+    END
+;
+
 """,  # noqa: E501
             )
 

--- a/src/ldlite/_database/duckdb.py
+++ b/src/ldlite/_database/duckdb.py
@@ -16,6 +16,7 @@ class DuckDbDatabase(TypedDatabase[duckdb.DuckDBPyConnection]):
 CREATE OR REPLACE FUNCTION ldlite_system.jextract(j, p) AS
     main.json_extract(j, p)
 ;
+
 CREATE OR REPLACE FUNCTION ldlite_system.jextract_string(j, p) AS
     main.json_extract_string(j, p)
 ;

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -29,6 +29,12 @@ BEGIN
     RETURN j->>p;
 END
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ldlite_system.jobject_keys(j JSONB) RETURNS SETOF TEXT AS $$
+BEGIN
+    RETURN QUERY SELECT jsonb_object_keys(j);
+END
+$$ LANGUAGE plpgsql;
 """,  # noqa: E501
             )
 

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -23,15 +23,12 @@ BEGIN
     RETURN j->p;
 END
 $$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION ldlite_system.jextract_string(j JSONB, p TEXT) RETURNS TEXT AS $$
 BEGIN
-    RETURN CASE
-        WHEN jsonb_typeof(j->p) NOT IN ('object', 'array') THEN j->>p
-        ELSE json_strip_nulls(j::JSON->p)::TEXT
-    END;
+    RETURN j->>p;
 END
 $$ LANGUAGE plpgsql;
-
 """,  # noqa: E501
             )
 

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -13,6 +13,19 @@ class PostgresDatabase(TypedDatabase[psycopg.Connection]):
         # same sql between duckdb and postgres
         super().__init__(lambda: psycopg.connect(dsn, cursor_factory=psycopg.RawCursor))
 
+    @staticmethod
+    def _setup_jfuncs(conn: psycopg.Connection) -> None:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+CREATE OR REPLACE FUNCTION ldlite_system.jextract(j JSONB, p TEXT) RETURNS JSONB AS $$
+BEGIN
+    RETURN j->p;
+END
+$$ LANGUAGE plpgsql;
+""",
+            )
+
     @property
     def _default_schema(self) -> str:
         return "public"

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -30,6 +30,7 @@ BEGIN
         WHEN ldlite_system.jtype_of(j->p) = 'string' THEN
             CASE
                 WHEN lower(j->>p) = 'null' THEN 'null'::JSONB
+                WHEN length(j->>p) = 0 THEN 'null'::JSONB
                 ELSE j->p
             END
         WHEN ldlite_system.jtype_of(j->p) = 'array' THEN
@@ -56,6 +57,15 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION ldlite_system.jobject_keys(j JSONB) RETURNS SETOF TEXT AS $$
 BEGIN
     RETURN QUERY SELECT jsonb_object_keys(j);
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ldlite_system.jis_uuid(j JSONB) RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN CASE
+        WHEN ldlite_system.jtype_of(j) = 'string' THEN j->>0 ~ '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$'
+        ELSE FALSE
+    END;
 END
 $$ LANGUAGE plpgsql;
 

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -72,7 +72,7 @@ $$ LANGUAGE plpgsql;
 CREATE OR REPLACE FUNCTION ldlite_system.jis_datetime(j JSONB) RETURNS BOOLEAN AS $$
 BEGIN
     RETURN CASE
-        WHEN ldlite_system.jtype_of(j) = 'string' THEN j->>0 ~ '^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$'
+        WHEN ldlite_system.jtype_of(j) = 'string' THEN j->>0 ~ '^\d{4}-[01]\d-[0123]\dT[012]\d:[012345]\d:[012345]\d\.\d{3}(\+\d{2}:\d{2})?$'
         ELSE FALSE
     END;
 END

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -35,6 +35,12 @@ BEGIN
     RETURN QUERY SELECT jsonb_object_keys(j);
 END
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ldlite_system.jtype_of(j JSONB) RETURNS TEXT AS $$
+BEGIN
+    RETURN jsonb_typeof(j);
+END
+$$ LANGUAGE plpgsql;
 """,  # noqa: E501
             )
 

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -17,7 +17,7 @@ class PostgresDatabase(TypedDatabase[psycopg.Connection]):
     def _setup_jfuncs(conn: psycopg.Connection) -> None:
         with conn.cursor() as cur:
             cur.execute(
-                """
+                r"""
 CREATE OR REPLACE FUNCTION ldlite_system.jtype_of(j JSONB) RETURNS TEXT AS $$
 BEGIN
     RETURN jsonb_typeof(j);
@@ -64,6 +64,15 @@ CREATE OR REPLACE FUNCTION ldlite_system.jis_uuid(j JSONB) RETURNS BOOLEAN AS $$
 BEGIN
     RETURN CASE
         WHEN ldlite_system.jtype_of(j) = 'string' THEN j->>0 ~ '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$'
+        ELSE FALSE
+    END;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ldlite_system.jis_datetime(j JSONB) RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN CASE
+        WHEN ldlite_system.jtype_of(j) = 'string' THEN j->>0 ~ '^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$'
         ELSE FALSE
     END;
 END

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -78,6 +78,15 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
+
+CREATE OR REPLACE FUNCTION ldlite_system.jis_float(j JSONB) RETURNS BOOLEAN AS $$
+BEGIN
+    RETURN CASE
+        WHEN ldlite_system.jtype_of(j) = 'number' THEN j->>0 LIKE '%.%'
+        ELSE FALSE
+    END;
+END
+$$ LANGUAGE plpgsql;
 """,  # noqa: E501
             )
 

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -41,6 +41,13 @@ BEGIN
     RETURN jsonb_typeof(j);
 END
 $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ldlite_system.jarray_length(j JSONB) RETURNS INTEGER AS $$
+BEGIN
+    RETURN jsonb_array_length(j);
+END
+$$ LANGUAGE plpgsql;
+
 """,  # noqa: E501
             )
 

--- a/src/ldlite/_database/postgres.py
+++ b/src/ldlite/_database/postgres.py
@@ -23,7 +23,16 @@ BEGIN
     RETURN j->p;
 END
 $$ LANGUAGE plpgsql;
-""",
+CREATE OR REPLACE FUNCTION ldlite_system.jextract_string(j JSONB, p TEXT) RETURNS TEXT AS $$
+BEGIN
+    RETURN CASE
+        WHEN jsonb_typeof(j->p) NOT IN ('object', 'array') THEN j->>p
+        ELSE json_strip_nulls(j::JSON->p)::TEXT
+    END;
+END
+$$ LANGUAGE plpgsql;
+
+""",  # noqa: E501
             )
 
     @property

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -160,6 +160,32 @@ FROM j;""",
     )
 
 
+@parametrize(
+    p=[
+        ("str", False),
+        ("str_empty", False),
+        ("num", False),
+        ("na", False),
+        ("na_str1", False),
+        ("na_str2", False),
+        ("uuid_nof", False),
+        ("uuid", False),
+        ("dt", False),
+        ("num", False),
+        ("float", True),
+    ],
+)
+def case_jis_float(p: tuple[Any, ...]) -> JsonTC:
+    return JsonTC(
+        """
+SELECT {assertion}ldlite_system.jis_float(jc->$1)
+FROM j;""",
+        p[:1],
+        "" if (p[1]) else """ NOT """,
+        (),
+    )
+
+
 def _assert(conn: "dbapi.DBAPIConnection", jtype: str, tc: JsonTC) -> None:
     with closing(conn.cursor()) as cur:
         query = tc.query.format(assertion="", jtype=jtype)

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -32,9 +32,11 @@ class JsonTC:
         ("str", '"str_val"'),
         ("num", "12"),
         ("float", "16.3"),
+        ("bool", "true"),
         ("obj", '{"k1":"v1","k2":"v2"}'),
         ("arr_str", '["s1","s2","s3"]'),
         ("arr_obj", '[{"k1":"v1"},{"k2":"v2"}]'),
+        ("na", "null"),
     ],
 )
 def case_jextract(p: tuple[Any, ...]) -> JsonTC:
@@ -51,13 +53,15 @@ def case_jextract(p: tuple[Any, ...]) -> JsonTC:
         ("str", "str_val"),
         ("num", "12"),
         ("float", "16.3"),
+        ("bool", "true"),
+        ("na",),
     ],
 )
 def case_jextract_string(p: tuple[Any, ...]) -> JsonTC:
     return JsonTC(
         """SELECT ldlite_system.jextract_string(jc, $1){assertion} FROM j;""",
         p[:1],
-        """ = $2""",
+        """ = $2""" if p[0] != "na" else """ IS NULL""",
         p[1:],
     )
 
@@ -82,9 +86,11 @@ WHERE e.jkey IS NULL or a.jkey IS NULL);""",
         ("str", "string"),
         ("num", "number"),
         ("float", "number"),
+        ("bool", "boolean"),
         ("obj", "object"),
         ("arr_str", "array"),
         ("arr_obj", "array"),
+        ("na", "null"),
     ],
 )
 def case_jtypeof(p: tuple[Any, ...]) -> JsonTC:
@@ -133,9 +139,11 @@ def duckdb_jop_dsn() -> Iterator[str]:
             """ "str": "str_val","""
             """ "num": 12,"""
             """ "float": 16.3,"""
+            """ "bool": true,"""
             """ "obj": {"k1": "v1", "k2": "v2"},"""
             """ "arr_str": ["s1", "s2", "s3"],"""
-            """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}]"""
+            """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}],"""
+            """ "na": null"""
             " }')",
         )
 
@@ -167,9 +175,11 @@ def pg_jop_dsn(pg_dsn: None | Callable[[str], str]) -> str:
             """ "str": "str_val","""
             """ "num": 12,"""
             """ "float": 16.3,"""
+            """ "bool": true,"""
             """ "obj": {"k1": "v1", "k2": "v2"},"""
             """ "arr_str": ["s1", "s2", "s3"],"""
-            """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}]"""
+            """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}],"""
+            """ "na": null"""
             " }')",
         )
     return dsn

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -104,6 +104,24 @@ FROM j;""",
     )
 
 
+@parametrize(
+    p=[
+        ("arr_zero", 0),
+        ("arr_str", 3),
+        ("arr_obj", 2),
+    ],
+)
+def case_jarray_length(p: tuple[Any, ...]) -> JsonTC:
+    return JsonTC(
+        """
+SELECT ldlite_system.jarray_length(ldlite_system.jextract(jc, $1)){assertion}
+FROM j;""",
+        p[:1],
+        """ = $2""",
+        p[1:],
+    )
+
+
 def _assert(conn: "dbapi.DBAPIConnection", jtype: str, tc: JsonTC) -> None:
     with closing(conn.cursor()) as cur:
         query = tc.query.format(assertion="", jtype=jtype)

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -1,0 +1,82 @@
+from collections.abc import Sequence
+from contextlib import closing
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
+
+import duckdb
+import pytest
+from pytest_cases import parametrize, parametrize_with_cases
+
+if TYPE_CHECKING:
+    from _typeshed import dbapi
+
+
+def _db() -> str:
+    db = "db" + str(uuid4()).split("-")[0]
+    print(db)  # noqa: T201
+    return db
+
+
+@dataclass
+class JsonTC:
+    assertion: str
+    params: Sequence[Any]
+    debug: str
+    debug_params: Sequence[Any]
+
+
+@parametrize(
+    p=[
+        ("str", '"str_val"'),
+        ("num", 12),
+        ("obj", '{"k1":"v1","k2":"v2"}'),
+        ("arr_str", '["s1","s2","s3"]'),
+        ("arr_obj", '[{"k1":"v1"},{"k2":"v2"}]'),
+    ],
+)
+def case_jextract(p: Sequence[Any]) -> JsonTC:
+    return JsonTC(
+        """SELECT ldlite_system.jextract(jc, $1) == $2 FROM j;""",
+        p,
+        """SELECT ldlite_system.jextract(jc, $1) FROM j;""",
+        p[:1],
+    )
+
+
+def _assert(conn: "dbapi.DBAPIConnection", tc: JsonTC) -> None:
+    with closing(conn.cursor()) as cur:
+        cur.execute(tc.assertion, tc.params)
+        actual = cur.fetchone()
+        assert actual is not None
+        assert actual[0] is not None
+    if not actual[0]:
+        conn.rollback()  # type:ignore[attr-defined]
+        with closing(conn.cursor()) as cur:
+            cur.execute(tc.debug, tc.debug_params)
+            pytest.fail(str(cur.fetchone()))
+
+
+@parametrize_with_cases("tc", cases=".")
+def test_duckdb(tc: JsonTC) -> None:
+    from ldlite import LDLite
+
+    ld = LDLite()
+    dsn = f":memory:{_db()}"
+    ld.connect_db(dsn)
+
+    with duckdb.connect(dsn) as conn:
+        conn.execute("CREATE TABLE j (jc JSON)")
+        conn.execute(
+            "INSERT INTO j VALUES "
+            "('{"
+            """ "str": "str_val","""
+            """ "num": 12,"""
+            """ "obj": {"k1": "v1", "k2": "v2"},"""
+            """ "arr_str": ["s1", "s2", "s3"],"""
+            """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}]"""
+            " }')",
+        )
+
+    with duckdb.connect(dsn) as conn, conn.begin() as tx:
+        _assert(cast("dbapi.DBAPIConnection", tx), tc)

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -47,6 +47,24 @@ def case_jextract(p: Sequence[Any]) -> JsonTC:
     )
 
 
+@parametrize(
+    p=[
+        ("str", "str_val"),
+        ("num", "12"),
+        ("obj", '{"k1":"v1","k2":"v2"}'),
+        ("arr_str", '["s1","s2","s3"]'),
+        ("arr_obj", '[{"k1":"v1"},{"k2":"v2"}]'),
+    ],
+)
+def case_jextract_string(p: Sequence[Any]) -> JsonTC:
+    return JsonTC(
+        """SELECT ldlite_system.jextract_string(jc, $1) = $2 FROM j;""",
+        p,
+        """SELECT ldlite_system.jextract_string(jc, $1) FROM j;""",
+        p[:1],
+    )
+
+
 def _assert(conn: "dbapi.DBAPIConnection", jtype: str, tc: JsonTC) -> None:
     with closing(conn.cursor()) as cur:
         if tc.format_type:

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -77,6 +77,27 @@ WHERE e.jkey IS NULL or a.jkey IS NULL);""",
     )
 
 
+@parametrize(
+    p=[
+        ("str", "string"),
+        ("num", "number"),
+        ("float", "number"),
+        ("obj", "object"),
+        ("arr_str", "array"),
+        ("arr_obj", "array"),
+    ],
+)
+def case_jtypeof(p: tuple[Any, ...]) -> JsonTC:
+    return JsonTC(
+        """
+SELECT ldlite_system.jtype_of(ldlite_system.jextract(jc, $1)){assertion}
+FROM j;""",
+        p[:1],
+        """ = $2""",
+        p[1:],
+    )
+
+
 def _assert(conn: "dbapi.DBAPIConnection", jtype: str, tc: JsonTC) -> None:
     with closing(conn.cursor()) as cur:
         query = tc.query.format(assertion="", jtype=jtype)

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -81,9 +81,9 @@ def case_jobject_keys() -> JsonTC:
 {assertion}
 (SELECT e.jkey, a.jkey
 FROM (SELECT 'k1' jkey UNION SELECT 'k2' jkey) as e
-FULL OUTER JOIN (SELECT ldlite_system.jobject_keys(jc->'obj') jkey FROM j) a
+FULL OUTER JOIN (SELECT ldlite_system.jobject_keys(jc->'obj') jkey FROM j) as a
     USING (jkey)
-WHERE e.jkey IS NULL or a.jkey IS NULL);""",
+WHERE e.jkey IS NULL or a.jkey IS NULL) as q;""",
         (),
         "SELECT COUNT(1) = 0 FROM ",
         (),

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -31,6 +31,7 @@ class JsonTC:
     p=[
         ("str", '"str_val"'),
         ("num", "12"),
+        ("float", "16.3"),
         ("obj", '{"k1":"v1","k2":"v2"}'),
         ("arr_str", '["s1","s2","s3"]'),
         ("arr_obj", '[{"k1":"v1"},{"k2":"v2"}]'),
@@ -49,6 +50,7 @@ def case_jextract(p: tuple[Any, ...]) -> JsonTC:
     p=[
         ("str", "str_val"),
         ("num", "12"),
+        ("float", "16.3"),
     ],
 )
 def case_jextract_string(p: tuple[Any, ...]) -> JsonTC:
@@ -89,6 +91,7 @@ def duckdb_jop_dsn() -> Iterator[str]:
             "('{"
             """ "str": "str_val","""
             """ "num": 12,"""
+            """ "float": 16.3,"""
             """ "obj": {"k1": "v1", "k2": "v2"},"""
             """ "arr_str": ["s1", "s2", "s3"],"""
             """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}]"""
@@ -122,6 +125,7 @@ def pg_jop_dsn(pg_dsn: None | Callable[[str], str]) -> str:
             "('{"
             """ "str": "str_val","""
             """ "num": 12,"""
+            """ "float": 16.3,"""
             """ "obj": {"k1": "v1", "k2": "v2"},"""
             """ "arr_str": ["s1", "s2", "s3"],"""
             """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}]"""

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -105,7 +105,7 @@ WHERE e.jkey IS NULL or a.jkey IS NULL);""",
 def case_jtypeof(p: tuple[Any, ...]) -> JsonTC:
     return JsonTC(
         """
-SELECT ldlite_system.jtype_of(ldlite_system.jextract(jc, $1)){assertion}
+SELECT ldlite_system.jtype_of(jc->$1){assertion}
 FROM j;""",
         p[:1],
         """ = $2""",
@@ -128,7 +128,31 @@ FROM j;""",
 def case_jis_uuid(p: tuple[Any, ...]) -> JsonTC:
     return JsonTC(
         """
-SELECT {assertion}ldlite_system.jis_uuid(ldlite_system.jextract(jc, $1))
+SELECT {assertion}ldlite_system.jis_uuid(jc->$1)
+FROM j;""",
+        p[:1],
+        "" if (p[1]) else """ NOT """,
+        (),
+    )
+
+
+@parametrize(
+    p=[
+        ("str", False),
+        ("str_empty", False),
+        ("num", False),
+        ("na", False),
+        ("na_str1", False),
+        ("na_str2", False),
+        ("uuid_nof", False),
+        ("uuid", False),
+        ("dt", True),
+    ],
+)
+def case_jis_datetime(p: tuple[Any, ...]) -> JsonTC:
+    return JsonTC(
+        """
+SELECT {assertion}ldlite_system.jis_datetime(jc->$1)
 FROM j;""",
         p[:1],
         "" if (p[1]) else """ NOT """,
@@ -179,6 +203,7 @@ def _arrange(conn: "dbapi.DBAPIConnection") -> None:
             """ "arr_str_some": ["s1", "s2", null],"""
             """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}],"""
             """ "arr_obj_some": [{"k1": "v1"}, null],"""
+            """ "dt": "2022-04-21T18:47:33.581+00:00","""
             """ "na": null,"""
             """ "na_str1": "null", """
             """ "na_str2": "NULL" """

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -1,10 +1,11 @@
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from contextlib import closing
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
 
 import duckdb
+import psycopg
 import pytest
 from pytest_cases import parametrize, parametrize_with_cases
 
@@ -21,15 +22,16 @@ def _db() -> str:
 @dataclass
 class JsonTC:
     assertion: str
-    params: Sequence[Any]
+    assertion_params: Sequence[Any]
     debug: str
     debug_params: Sequence[Any]
+    format_type: bool = False
 
 
 @parametrize(
     p=[
         ("str", '"str_val"'),
-        ("num", 12),
+        ("num", "12"),
         ("obj", '{"k1":"v1","k2":"v2"}'),
         ("arr_str", '["s1","s2","s3"]'),
         ("arr_obj", '[{"k1":"v1"},{"k2":"v2"}]'),
@@ -37,16 +39,20 @@ class JsonTC:
 )
 def case_jextract(p: Sequence[Any]) -> JsonTC:
     return JsonTC(
-        """SELECT ldlite_system.jextract(jc, $1) == $2 FROM j;""",
+        """SELECT ldlite_system.jextract(jc, $1) = $2::{jtype} FROM j;""",
         p,
         """SELECT ldlite_system.jextract(jc, $1) FROM j;""",
         p[:1],
+        format_type=True,
     )
 
 
-def _assert(conn: "dbapi.DBAPIConnection", tc: JsonTC) -> None:
+def _assert(conn: "dbapi.DBAPIConnection", jtype: str, tc: JsonTC) -> None:
     with closing(conn.cursor()) as cur:
-        cur.execute(tc.assertion, tc.params)
+        if tc.format_type:
+            cur.execute(tc.assertion.format(jtype=jtype), tc.assertion_params)
+        else:
+            cur.execute(tc.assertion, tc.assertion_params)
         actual = cur.fetchone()
         assert actual is not None
         assert actual[0] is not None
@@ -79,4 +85,32 @@ def test_duckdb(tc: JsonTC) -> None:
         )
 
     with duckdb.connect(dsn) as conn, conn.begin() as tx:
-        _assert(cast("dbapi.DBAPIConnection", tx), tc)
+        _assert(cast("dbapi.DBAPIConnection", tx), "JSON", tc)
+
+
+@parametrize_with_cases("tc", cases=".")
+def test_postgres(pg_dsn: None | Callable[[str], str], tc: JsonTC) -> None:
+    if pg_dsn is None:
+        pytest.skip("Specify the pg host using --pg-host to run")
+
+    from ldlite import LDLite
+
+    ld = LDLite()
+    dsn = pg_dsn(_db())
+    ld.connect_db_postgresql(dsn)
+
+    with psycopg.connect(dsn) as conn, conn.cursor() as cur:
+        cur.execute("CREATE TABLE j (jc JSONB)")
+        cur.execute(
+            "INSERT INTO j VALUES "
+            "('{"
+            """ "str": "str_val","""
+            """ "num": 12,"""
+            """ "obj": {"k1": "v1", "k2": "v2"},"""
+            """ "arr_str": ["s1", "s2", "s3"],"""
+            """ "arr_obj": [{"k1": "v1"}, {"k2": "v2"}]"""
+            " }')",
+        )
+
+    with psycopg.connect(dsn, cursor_factory=psycopg.RawCursor) as conn:
+        _assert(cast("dbapi.DBAPIConnection", conn), "JSONB", tc)

--- a/tests/test_json_operators.py
+++ b/tests/test_json_operators.py
@@ -30,6 +30,7 @@ class JsonTC:
 @parametrize(
     p=[
         ("str", '"str_val"'),
+        ("str_empty", "null"),
         ("num", "12"),
         ("float", "16.3"),
         ("bool", "true"),
@@ -112,6 +113,29 @@ FROM j;""",
     )
 
 
+@parametrize(
+    p=[
+        ("str", False),
+        ("str_empty", False),
+        ("num", False),
+        ("na", False),
+        ("na_str1", False),
+        ("na_str2", False),
+        ("uuid_nof", False),
+        ("uuid", True),
+    ],
+)
+def case_jis_uuid(p: tuple[Any, ...]) -> JsonTC:
+    return JsonTC(
+        """
+SELECT {assertion}ldlite_system.jis_uuid(ldlite_system.jextract(jc, $1))
+FROM j;""",
+        p[:1],
+        "" if (p[1]) else """ NOT """,
+        (),
+    )
+
+
 def _assert(conn: "dbapi.DBAPIConnection", jtype: str, tc: JsonTC) -> None:
     with closing(conn.cursor()) as cur:
         query = tc.query.format(assertion="", jtype=jtype)
@@ -141,9 +165,12 @@ def _arrange(conn: "dbapi.DBAPIConnection") -> None:
             "INSERT INTO j VALUES "
             "('{"
             """ "str": "str_val","""
+            """ "str_empty": "","""
             """ "num": 12,"""
             """ "float": 16.3,"""
             """ "bool": true,"""
+            """ "uuid": "5b285d03-5490-1111-8888-52b2003b475c","""
+            """ "uuid_nof": "5b285d03-5490-FFFF-0000-52b2003b475c","""
             """ "obj": {"k1": "v1", "k2": "v2"},"""
             """ "obj_some": {"k1": "v1", "k2": null},"""
             """ "obj_empty": {},"""


### PR DESCRIPTION
The plan to speed up json transformation is to do it all in SQL using the native json functionality. A proof of concept and some napkin math has this running around 10x faster. In order to not have to duplicate the transformation queries (which will be complicated) we're adding abstractions over the native functionality in duckdb and postgres. This will allow us to write one query that is agnostic to the underlying engine.

Duckdb was in particular hard to get the versioning correct with as they like to have incompatibilities between versions. I think the version check and setting is a reasonable way to keep it consistent but we'll see if it becomes unmaintainable.

Postgres compatibility has been tested from 13.22+.

There's no actual functionality changes here but the PR was already getting huge before starting to do the actual big refactor for the transformation.